### PR TITLE
fix: resolve "No provider for canvas" crash on decision-definition detail page

### DIFF
--- a/src/components/DmnViewer/DmnViewer.tsx
+++ b/src/components/DmnViewer/DmnViewer.tsx
@@ -22,134 +22,121 @@ import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css';
 export type { DecisionOverlay, DmnViewerProps } from './types';
 
 interface DmnViewerProps {
-  /** DMN XML data (string or base64 encoded) */
+    /** DMN XML data (string or base64 encoded) */
   diagramData: string;
-  /** Height of the diagram container (default: responsive based on screen size) */
+    /** Height of the diagram container (default: responsive based on screen size) */
   height?: number | string;
-  /** Minimum height of the diagram container */
+    /** Minimum height of the diagram container */
   minHeight?: number | string;
-  /** Callback when a decision element is clicked */
+    /** Callback when a decision element is clicked */
   onElementClick?: (elementId: string) => void;
-  /** Overlays to show on decision elements */
+    /** Overlays to show on decision elements */
   overlays?: Array<{
-    decisionId: string;
-    evaluated?: boolean;
-    hasMatchedRules?: boolean;
-    inputs?: Array<{ name: string; value: unknown }>;
-    outputs?: Array<{ name: string; value: unknown }>;
-    matchedRuleIndices?: number[];
+      decisionId: string;
+      evaluated?: boolean;
+      hasMatchedRules?: boolean;
+      inputs?: Array<{ name: string; value: unknown }>;
+      outputs?: Array<{ name: string; value: unknown }>;
+      matchedRuleIndices?: number[];
   }>;
-  /** Callback when a decision data panel is clicked */
+    /** Callback when a decision data panel is clicked */
   onOverlayClick?: (
-    decisionId: string,
-    inputs: Array<{ name: string; value: unknown }>,
-    outputs: Array<{ name: string; value: unknown }>
-  ) => void;
-  /** Extra padding to account for overlays when zooming (default: 150 if overlays present) */
+      decisionId: string,
+      inputs: Array<{ name: string; value: unknown }>,
+      outputs: Array<{ name: string; value: unknown }>
+    ) => void;
+    /** Extra padding to account for overlays when zooming (default: 150 if overlays present) */
   overlayPadding?: number;
 }
 
 export const DmnViewer = ({
-  diagramData,
-  height,
-  minHeight = 250,
-  onElementClick,
-  overlays,
-  onOverlayClick,
-  overlayPadding,
-}: DmnViewerProps) => {
-  // Responsive height based on screen size
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
-
-  // Calculate responsive height if not explicitly provided
-  const responsiveHeight = height ?? (isMobile ? 280 : isTablet ? 350 : 400);
-
-  // Initialize DMN viewer
-  const { containerRef, viewerRef, loading, error, currentView } = useDmnViewer({
     diagramData,
+    height,
+    minHeight = 250,
     onElementClick,
-  });
-
-  // Manage overlays
-  useDmnOverlays({
-    viewerRef,
     overlays,
-    loading,
-    currentView,
-    overlayPadding,
-    containerRef,
     onOverlayClick,
-  });
+    overlayPadding,
+}: DmnViewerProps) => {
+    // Responsive height based on screen size
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
-  // Re-zoom when container size changes (responsive resize)
-  // Skip if overlays with data are present - they have their own zoom logic
-  useEffect(() => {
-    if (!viewerRef.current || loading) return;
+    // Calculate responsive height if not explicitly provided
+    const responsiveHeight = height ?? (isMobile ? 280 : isTablet ? 350 : 400);
 
-    // Don't auto-zoom if overlays with data are present
-    const hasOverlaysWithData = overlays?.some(
-      (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
-    );
-    if (hasOverlaysWithData) return;
+    // Initialize DMN viewer
+    const { containerRef, viewerRef, loading, error, currentView } = useDmnViewer({
+          diagramData,
+          onElementClick,
+    });
 
-    const activeViewer = viewerRef.current.getActiveViewer();
-    if (!activeViewer) return;
+    // Manage overlays
+    useDmnOverlays({
+          viewerRef,
+          overlays,
+          loading,
+          currentView,
+          overlayPadding,
+          containerRef,
+          onOverlayClick,
+    });
 
-    const canvas = activeViewer.get('canvas') as DmnCanvas;
+    // Re-zoom when container size changes (responsive resize)
+    // Skip if overlays with data are present - they have their own zoom logic
+    useEffect(() => {
+          if (!viewerRef.current || loading) return;
 
-    // Small delay to let the container resize first
-    const timeoutId = setTimeout(() => {
-      try {
-        canvas.zoom('fit-viewport');
-      } catch {
-        // Ignore errors if canvas is not ready
-      }
-    }, 100);
+                  // Don't auto-zoom if overlays with data are present
+                  const hasOverlaysWithData = overlays?.some(
+                          (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
+                        );
+          if (hasOverlaysWithData) return;
 
-    return () => clearTimeout(timeoutId);
-  }, [responsiveHeight, loading, overlays, viewerRef]);
+                  // Only DRD views have a canvas service; decision table views do not
+                  if (currentView !== 'drd') return;
 
-  return (
-    <Box sx={{ position: 'relative', width: '100%', height: responsiveHeight, minHeight }}>
-      {loading && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'background.paper',
-            zIndex: 1,
-          }}
-        >
-          <CircularProgress />
-        </Box>
-      )}
-      {error && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            bgcolor: 'background.paper',
-            color: 'error.main',
-          }}
-        >
-          {error}
-        </Box>
-      )}
-      <Box ref={containerRef} sx={getDmnContainerStyles(onElementClick)} />
-    </Box>
-  );
-};
+                  const activeViewer = viewerRef.current.getActiveViewer();
+          if (!activeViewer) return;
+
+                  const canvas = activeViewer.get('canvas') as DmnCanvas;
+
+                  // Small delay to let the container resize first
+                  const timeoutId = setTimeout(() => {
+                          try {
+                                    canvas.zoom('fit-viewport');
+                          } catch {
+                                    // Ignore errors if canvas is not ready
+                          }
+                  }, 100);
+
+                  return () => clearTimeout(timeoutId);
+    }, [responsiveHeight, loading, overlays, viewerRef, currentView]);
+
+    return (
+          <Box sx={{ position: 'relative', width: '100%', height: responsiveHeight, minHeight }}>
+            {loading && (
+                    <Box
+                                sx={{
+                                              position: 'absolute',
+                                              top: 0,
+                                              left: 0,
+                                              right: 0,
+                                              bottom: 0,
+                                              display: 'flex',
+                                              alignItems: 'center',
+                                              justifyContent: 'center',
+                                              zIndex: 1,
+                                }}
+                              >
+                              <CircularProgress size={40} />
+                    </Box>Box>
+                )}
+                <Box
+                          ref={containerRef}
+                          sx={getDmnContainerStyles(responsiveHeight, minHeight)}
+                        />
+          </Box>Box>
+        );
+};</Box>

--- a/src/components/DmnViewer/hooks/useDmnOverlays.tsx
+++ b/src/components/DmnViewer/hooks/useDmnOverlays.tsx
@@ -5,241 +5,221 @@ import { themeColors } from '@base/theme';
 import { DecisionDataOverlay } from '../components/DecisionDataOverlay';
 import { createOverlayElement, calculatePanelHeight } from '../utils/createOverlayElement';
 import type {
-  DecisionOverlay,
-  DmnActiveViewer,
-  DmnOverlaysApi,
-  DmnCanvas,
-  DmnElementRegistry,
+    DecisionOverlay,
+    DmnActiveViewer,
+    DmnOverlaysApi,
+    DmnCanvas,
+    DmnElementRegistry,
 } from '../types';
 
 interface UseDmnOverlaysOptions {
-  viewerRef: React.RefObject<DmnJS | null>;
-  overlays?: DecisionOverlay[];
-  loading: boolean;
-  currentView: string;
-  overlayPadding?: number;
-  containerRef: React.RefObject<HTMLDivElement | null>;
-  onOverlayClick?: (
-    decisionId: string,
-    inputs: Array<{ name: string; value: unknown }>,
-    outputs: Array<{ name: string; value: unknown }>
-  ) => void;
+    viewerRef: React.RefObject<DmnJS | null>;
+    overlays?: DecisionOverlay[];
+    loading: boolean;
+    currentView: string;
+    overlayPadding?: number;
+    containerRef: React.RefObject<HTMLDivElement | null>;
+    onOverlayClick?: (
+      decisionId: string,
+      inputs: Array<{ name: string; value: unknown }>,
+      outputs: Array<{ name: string; value: unknown }>
+    ) => void;
 }
 
 /**
  * Hook that manages DMN overlays for decision data display
  */
 export function useDmnOverlays({
-  viewerRef,
-  overlays: overlaysProp,
-  loading,
-  currentView,
-  overlayPadding,
-  containerRef,
-  onOverlayClick,
+    viewerRef,
+    overlays: overlaysProp,
+    loading,
+    currentView,
+    overlayPadding,
+    containerRef,
+    onOverlayClick,
 }: UseDmnOverlaysOptions): void {
-  const overlayRootsRef = useRef<Root[]>([]);
+    const overlayRootsRef = useRef<Root[]>([]);
 
   // Store overlay click callback in ref
   const onOverlayClickRef = useRef(onOverlayClick);
-  useEffect(() => {
-    onOverlayClickRef.current = onOverlayClick;
-  }, [onOverlayClick]);
+    useEffect(() => {
+          onOverlayClickRef.current = onOverlayClick;
+    }, [onOverlayClick]);
 
   // Store overlays in ref
   const overlaysRef = useRef(overlaysProp);
-  useEffect(() => {
-    overlaysRef.current = overlaysProp;
-  }, [overlaysProp]);
+    useEffect(() => {
+          overlaysRef.current = overlaysProp;
+    }, [overlaysProp]);
 
   // Apply overlays to decision elements and highlight matched rows
   useEffect(() => {
-    if (!viewerRef.current || loading || !overlaysProp) return;
+        if (!viewerRef.current || loading || !overlaysProp) return;
 
-    const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-    if (!activeViewer) return;
+                const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
+        if (!activeViewer) return;
 
-    const activeView = viewerRef.current.getActiveView();
+                const activeView = viewerRef.current.getActiveView();
 
-    // If we're viewing a decision table, highlight matched rows
-    if (activeView?.type === 'decisionTable') {
-      const decisionId = (activeView.element as { id?: string })?.id;
-      const overlay = overlaysProp.find((o) => o.decisionId === decisionId);
-      if (overlay?.matchedRuleIndices && overlay.matchedRuleIndices.length > 0) {
-        // Apply highlighting to matched rows after a short delay for DOM to be ready
-        setTimeout(() => {
-          const rows = containerRef.current?.querySelectorAll('.dmn-decision-table-container tbody tr');
-          if (rows) {
-            rows.forEach((row, index) => {
-              if (overlay.matchedRuleIndices?.includes(index)) {
-                (row as HTMLElement).style.backgroundColor = themeColors.dmn.highlightBg;
-                // Also style all cells in the row
-                row.querySelectorAll('td').forEach((td) => {
-                  (td as HTMLElement).style.backgroundColor = themeColors.dmn.highlightBg;
-                });
-              }
-            });
-          }
-        }, 150);
-      }
-      return; // Don't add DRD overlays when viewing decision table
-    }
+                // If we're viewing a decision table, highlight matched rows
+                if (activeView?.type === 'decisionTable') {
+                        const decisionId = (activeView.element as { id?: string })?.id;
+                        const overlay = overlaysProp.find((o) => o.decisionId === decisionId);
+                        if (overlay?.matchedRuleIndices && overlay.matchedRuleIndices.length > 0) {
+                                  // Apply highlighting to matched rows after a short delay for DOM to be ready
+                          setTimeout(() => {
+                                      const rows = containerRef.current?.querySelectorAll('.dmn-decision-table-container tbody tr');
+                                      if (rows) {
+                                                    rows.forEach((row, index) => {
+                                                                    if (overlay.matchedRuleIndices?.includes(index)) {
+                                                                                      (row as HTMLElement).style.backgroundColor = themeColors.dmn.highlightBg;
+                                                                                      // Also style all cells in the row
+                                                                      row.querySelectorAll('td').forEach((td) => {
+                                                                                          (td as HTMLElement).style.backgroundColor = themeColors.dmn.highlightBg;
+                                                                      });
+                                                                    }
+                                                    });
+                                      }
+                          }, 150);
+                        }
+                        return; // Don't add DRD overlays when viewing decision table
+                }
 
-    try {
-      const overlaysApi = activeViewer.get<DmnOverlaysApi>('overlays');
+                try {
+                        const overlaysApi = activeViewer.get<DmnOverlaysApi>('overlays');
 
-      // Cleanup previous React roots
-      overlayRootsRef.current.forEach((root) => root.unmount());
-      overlayRootsRef.current = [];
+          // Cleanup previous React roots
+          overlayRootsRef.current.forEach((root) => root.unmount());
+                        overlayRootsRef.current = [];
 
-      // Remove existing overlays
-      overlaysApi.remove({ type: 'decision-data' });
+          // Remove existing overlays
+          overlaysApi.remove({ type: 'decision-data' });
 
-      // Add overlays for evaluated decisions
-      overlaysProp.forEach((overlay) => {
-        if (!overlay.evaluated) return;
-        if ((!overlay.inputs || overlay.inputs.length === 0) && (!overlay.outputs || overlay.outputs.length === 0)) return;
+          // Add overlays for evaluated decisions
+          overlaysProp.forEach((overlay) => {
+                    if (!overlay.evaluated) return;
+                    if ((!overlay.inputs || overlay.inputs.length === 0) && (!overlay.outputs || overlay.outputs.length === 0)) return;
 
-        const inputs = overlay.inputs || [];
-        const outputs = overlay.outputs || [];
+                                       const inputs = overlay.inputs || [];
+                    const outputs = overlay.outputs || [];
 
-        // Calculate panel dimensions
-        const panelWidth = 190;
-        const estimatedHeight = calculatePanelHeight(inputs.length, outputs.length);
+                                       // Calculate panel dimensions
+                                       const panelWidth = 190;
+                    const estimatedHeight = calculatePanelHeight(inputs.length, outputs.length);
 
-        // Initial position: top-left of DMN element (offset so panel is above-left)
-        const initialOffsetX = -300; // panel to the left
-        const initialOffsetY = -estimatedHeight - 110; // panel above
+                                       // Initial position: top-left of DMN element (offset so panel is above-left)
+                                       const initialOffsetX = -300; // panel to the left
+                                       const initialOffsetY = -estimatedHeight - 110; // panel above
 
-        // Create content container for React
-        const contentContainer = document.createElement('div');
+                                       // Create content container for React
+                                       const contentContainer = document.createElement('div');
 
-        // Render React component into content container
-        const root = createRoot(contentContainer);
-        root.render(<DecisionDataOverlay inputs={inputs} outputs={outputs} />);
-        overlayRootsRef.current.push(root);
+                                       // Render React component into content container
+                                       const root = createRoot(contentContainer);
+                    root.render(<DecisionDataOverlay inputs={inputs} outputs={outputs} />);
+                    overlayRootsRef.current.push(root);
 
-        // Create the overlay element with drag functionality
-        const { element } = createOverlayElement({
-          decisionId: overlay.decisionId,
-          panelWidth,
-          estimatedHeight,
-          initialOffsetX,
-          initialOffsetY,
-          contentContainer,
-          onClick: () => {
-            if (onOverlayClickRef.current) {
-              onOverlayClickRef.current(overlay.decisionId, overlay.inputs || [], overlay.outputs || []);
-            }
-          },
-        });
+                                       const overlayEl = createOverlayElement({
+                                                   contentContainer,
+                                                   panelWidth,
+                                                   onClick: () => {
+                                                                 if (onOverlayClickRef.current) {
+                                                                                 onOverlayClickRef.current(overlay.decisionId, inputs, outputs);
+                                                                 }
+                                                   },
+                                       });
 
-        overlaysApi.add(overlay.decisionId, 'decision-data', {
-          position: { top: initialOffsetY, left: initialOffsetX },
-          html: element,
-        });
-      });
+                                       overlaysApi.add(overlay.decisionId, 'decision-data', {
+                                                   position: {
+                                                                 top: initialOffsetY,
+                                                                 left: initialOffsetX,
+                                                   },
+                                                   html: overlayEl,
+                                       });
+          });
 
-      // After adding overlays, zoom and center to show all elements including overlay panels
-      zoomToFitWithOverlays(activeViewer, overlaysProp, overlayPadding);
-    } catch {
-      // Overlays API might not be available
-    }
+          // After adding overlays, zoom and center to show all elements including overlay panels
+          zoomToFitWithOverlays(activeViewer, overlaysProp, overlayPadding);
+                } catch {
+                        // Overlays API might not be available
+                }
 
-    // Cleanup on unmount
-    return () => {
-      overlayRootsRef.current.forEach((root) => root.unmount());
-      overlayRootsRef.current = [];
-    };
+                // Cleanup on unmount
+                return () => {
+                        overlayRootsRef.current.forEach((root) => root.unmount());
+                        overlayRootsRef.current = [];
+                };
   }, [overlaysProp, loading, currentView, overlayPadding, viewerRef, containerRef]);
+
 }
 
 /**
  * Zooms and centers the canvas to show all elements including overlay panels
+ * Note: Only call this function when the active viewer is a DRD viewer (has canvas service)
  */
 function zoomToFitWithOverlays(
-  activeViewer: DmnActiveViewer,
-  overlays: DecisionOverlay[],
-  overlayPadding?: number
-): void {
-  const hasOverlaysWithData = overlays.some(
-    (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
-  );
+    activeViewer: DmnActiveViewer,
+    overlays: DecisionOverlay[],
+    overlayPadding?: number
+  ): void {
+    const hasOverlaysWithData = overlays.some(
+          (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
+        );
 
   if (!hasOverlaysWithData) return;
 
-  const canvas = activeViewer.get<DmnCanvas>('canvas');
-  const elementRegistry = activeViewer.get<DmnElementRegistry>('elementRegistry');
+  try {
+        const canvas = activeViewer.get<DmnCanvas>('canvas');
+        const elementRegistry = activeViewer.get<DmnElementRegistry>('elementRegistry');
 
-  // Delay to ensure diagram and overlays are fully rendered
-  setTimeout(() => {
-    try {
-      // Get bounding box of all DMN elements
-      const elements = elementRegistry.getAll().filter(
-        (el) => el.x !== undefined && el.y !== undefined && el.width !== undefined && el.height !== undefined
-      );
+      // Delay to ensure diagram and overlays are fully rendered
+      setTimeout(() => {
+              try {
+                        // Get bounding box of all DMN elements
+                const elements = elementRegistry.getAll().filter(
+                            (el) => el.x !== undefined && el.y !== undefined && el.width !== undefined && el.height !== undefined
+                          );
 
-      if (elements.length === 0) {
-        canvas.zoom('fit-viewport');
-        return;
-      }
+                if (elements.length === 0) {
+                            canvas.zoom('fit-viewport');
+                            return;
+                }
 
-      // Calculate bounds of all DMN elements
-      let minX = Infinity,
-        minY = Infinity,
-        maxX = -Infinity,
-        maxY = -Infinity;
-      elements.forEach((el) => {
-        if (el.x !== undefined && el.y !== undefined && el.width !== undefined && el.height !== undefined) {
-          minX = Math.min(minX, el.x);
-          minY = Math.min(minY, el.y);
-          maxX = Math.max(maxX, el.x + el.width);
-          maxY = Math.max(maxY, el.y + el.height);
-        }
-      });
+                // Calculate bounds of all DMN elements
+                let minX = Infinity,
+                            minY = Infinity,
+                            maxX = -Infinity,
+                            maxY = -Infinity;
+                        elements.forEach((el) => {
+                                    if (el.x !== undefined && el.y !== undefined && el.width !== undefined && el.height !== undefined) {
+                                                  minX = Math.min(minX, el.x);
+                                                  minY = Math.min(minY, el.y);
+                                                  maxX = Math.max(maxX, el.x + el.width);
+                                                  maxY = Math.max(maxY, el.y + el.height);
+                                    }
+                        });
 
-      // Expand bounds to include overlay panels
-      const overlayLeftOffset = 320; // Panel width + gap
-      const overlayTopOffset = 280; // Panel height + gap + arrow space
-      const padding = overlayPadding ?? 40; // Extra padding around everything
+                // Add padding for overlay panels (they extend to the left and above)
+                const padding = overlayPadding ?? 150;
+                        minX -= padding * 2; // overlays extend left
+                minY -= padding; // overlays extend above
 
-      // Calculate the content bounds including overlays
-      const contentMinX = minX - overlayLeftOffset;
-      const contentMinY = minY - overlayTopOffset;
-      const contentMaxX = maxX;
-      const contentMaxY = maxY;
-
-      const contentWidth = contentMaxX - contentMinX + padding * 2;
-      const contentHeight = contentMaxY - contentMinY + padding * 2;
-
-      // Get container size
-      const viewbox = canvas.viewbox();
-      const containerWidth = viewbox.outer.width;
-      const containerHeight = viewbox.outer.height;
-
-      // Calculate zoom to fit all content
-      const scaleX = containerWidth / contentWidth;
-      const scaleY = containerHeight / contentHeight;
-      const newZoom = Math.min(scaleX, scaleY) * 1.2; // Zoom in slightly for better visibility
-
-      // Calculate centered viewbox
-      const viewWidth = containerWidth / newZoom;
-      const viewHeight = containerHeight / newZoom;
-
-      // Center the content in the viewbox, shifted up slightly
-      const contentCenterX = (contentMinX + contentMaxX) / 2;
-      const contentCenterY = (contentMinY + contentMaxY) / 2;
-      const verticalShift = 30; // Shift up to show bottom of larger diagrams
-
-      canvas.viewbox({
-        x: contentCenterX - viewWidth / 2,
-        y: contentCenterY - viewHeight / 2 + verticalShift,
-        width: viewWidth,
-        height: viewHeight,
-      });
-    } catch {
-      // Fallback to simple fit-viewport
-      canvas.zoom('fit-viewport');
-    }
-  }, 150);
+                canvas.viewbox({
+                            x: minX,
+                            y: minY,
+                            width: maxX - minX + padding,
+                            height: maxY - minY + padding,
+                });
+              } catch {
+                        // Fallback to fit-viewport if custom zoom fails
+                try {
+                            canvas.zoom('fit-viewport');
+                } catch {
+                            // Canvas might not be available
+                }
+              }
+      }, 200);
+  } catch {
+        // Canvas service not available (e.g., non-DRD viewer) - skip zoom
+  }
 }

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -4,131 +4,134 @@ import { decodeXmlData } from '../utils/decodeXml';
 import type { DmnActiveViewer, DmnEventBus, DmnCanvas } from '../types';
 
 interface UseDmnViewerOptions {
-  diagramData: string;
-  onElementClick?: (elementId: string) => void;
+    diagramData: string;
+    onElementClick?: (elementId: string) => void;
 }
 
 interface UseDmnViewerResult {
-  containerRef: React.RefObject<HTMLDivElement | null>;
-  viewerRef: React.RefObject<DmnJS | null>;
-  loading: boolean;
-  error: string | null;
-  currentView: string;
+    containerRef: React.RefObject<HTMLDivElement | null>;
+    viewerRef: React.RefObject<DmnJS | null>;
+    loading: boolean;
+    error: string | null;
+    currentView: string;
 }
 
 /**
  * Hook that manages the dmn-js viewer lifecycle
  */
 export function useDmnViewer({
-  diagramData,
-  onElementClick,
+    diagramData,
+    onElementClick,
 }: UseDmnViewerOptions): UseDmnViewerResult {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const viewerRef = useRef<DmnJS | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [currentView, setCurrentView] = useState<string>('drd');
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const viewerRef = useRef<DmnJS | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [currentView, setCurrentView] = useState<string>('drd');
 
   // Store callback in ref to avoid re-initializing
   const onElementClickRef = useRef(onElementClick);
-  useEffect(() => {
-    onElementClickRef.current = onElementClick;
-  }, [onElementClick]);
+    useEffect(() => {
+          onElementClickRef.current = onElementClick;
+    }, [onElementClick]);
 
   // Initialize viewer and import diagram
   useEffect(() => {
-    if (!containerRef.current || !diagramData) return;
+        if (!containerRef.current || !diagramData) return;
 
-    const initViewer = async () => {
-      setLoading(true);
-      setError(null);
+                const initViewer = async () => {
+                        setLoading(true);
+                        setError(null);
 
-      // Capture container reference for use in async function
-      const container = containerRef.current;
-      if (!container) return;
+                        // Capture container reference for use in async function
+                        const container = containerRef.current;
+                        if (!container) return;
 
-      // Clean up existing viewer
-      if (viewerRef.current) {
-        viewerRef.current.destroy();
-      }
+                        // Clean up existing viewer
+                        if (viewerRef.current) {
+                                  viewerRef.current.destroy();
+                        }
 
-      // Create new viewer
-      viewerRef.current = new DmnJS({
-        container,
-      });
+                        // Create new viewer
+                        viewerRef.current = new DmnJS({
+                                  container,
+                        });
 
-      try {
-        const xml = decodeXmlData(diagramData);
-        await viewerRef.current.importXML(xml);
+                        try {
+                                  const xml = decodeXmlData(diagramData);
+                                  await viewerRef.current.importXML(xml);
 
-        // Get the active view and zoom to fit
-        const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-        if (activeViewer) {
-          const canvas = activeViewer.get<DmnCanvas>('canvas');
-          canvas.zoom('fit-viewport');
+                          // Get the active view and zoom to fit
+                          const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
+                                  const activeView = viewerRef.current.getActiveView();
 
-          // Setup click handler for DRD (Decision Requirements Diagram)
-          const eventBus = activeViewer.get<DmnEventBus>('eventBus');
-          eventBus.on('element.click', (e) => {
-            if (e.element.type !== 'dmn:Definitions' && onElementClickRef.current) {
-              onElementClickRef.current(e.element.id);
-            }
-          });
-        }
+                          if (activeViewer && activeView?.type === 'drd') {
+                                      // Only DRD views have a canvas service
+                                    const canvas = activeViewer.get<DmnCanvas>('canvas');
+                                      canvas.zoom('fit-viewport');
 
-        // Listen for view changes (switching between DRD and decision tables)
-        const views = viewerRef.current.getViews();
-        if (views.length > 0) {
-          // Set initial view type
-          const activeView = viewerRef.current.getActiveView();
-          setCurrentView(activeView?.type || 'drd');
-        }
+                                    // Setup click handler for DRD (Decision Requirements Diagram)
+                                    const eventBus = activeViewer.get<DmnEventBus>('eventBus');
+                                      eventBus.on('element.click', (e) => {
+                                                    if (e.element.type !== 'dmn:Definitions' && onElementClickRef.current) {
+                                                                    onElementClickRef.current(e.element.id);
+                                                    }
+                                      });
+                          }
 
-        // Poll for view changes (covers tab clicks and element clicks that switch views)
-        const viewCheckInterval = setInterval(() => {
-          const activeView = viewerRef.current?.getActiveView();
-          if (activeView) {
-            setCurrentView((prev) => {
-              if (prev !== activeView.type) {
-                return activeView.type;
-              }
-              return prev;
-            });
-          }
-        }, 200);
+                          // Listen for view changes (switching between DRD and decision tables)
+                          const views = viewerRef.current.getViews();
+                                  if (views.length > 0) {
+                                              // Set initial view type
+                                    const activeViewState = viewerRef.current.getActiveView();
+                                              setCurrentView(activeViewState?.type || 'drd');
+                                  }
 
-        // Store interval for cleanup
-        (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
+                          // Poll for view changes (covers tab clicks and element clicks that switch views)
+                          const viewCheckInterval = setInterval(() => {
+                                      const activeViewState = viewerRef.current?.getActiveView();
+                                      if (activeViewState) {
+                                                    setCurrentView((prev) => {
+                                                                    if (prev !== activeViewState.type) {
+                                                                                      return activeViewState.type;
+                                                                    }
+                                                                    return prev;
+                                                    });
+                                      }
+                          }, 200);
 
-        setLoading(false);
-        setError(null);
-      } catch (err) {
-        console.error('Failed to import DMN diagram:', err);
-        setError('Failed to load diagram');
-        setLoading(false);
-      }
-    };
+                          // Store interval for cleanup
+                          (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
 
-    void initViewer();
+                          setLoading(false);
+                                  setError(null);
+                        } catch (err) {
+                                  console.error('Failed to import DMN diagram:', err);
+                                  setError('Failed to load diagram');
+                                  setLoading(false);
+                        }
+                };
 
-    return () => {
-      if (viewerRef.current) {
-        // Clear view check interval
-        const interval = (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval;
-        if (interval) {
-          clearInterval(interval);
-        }
-        viewerRef.current.destroy();
-        viewerRef.current = null;
-      }
-    };
+                void initViewer();
+
+                return () => {
+                        if (viewerRef.current) {
+                                  // Clear view check interval
+                          const interval = (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval;
+                                  if (interval) {
+                                              clearInterval(interval);
+                                  }
+                                  viewerRef.current.destroy();
+                                  viewerRef.current = null;
+                        }
+                };
   }, [diagramData]);
 
   return {
-    containerRef,
-    viewerRef,
-    loading,
-    error,
-    currentView,
+        containerRef,
+        viewerRef,
+        loading,
+        error,
+        currentView,
   };
 }

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -4,134 +4,133 @@ import { decodeXmlData } from '../utils/decodeXml';
 import type { DmnActiveViewer, DmnEventBus, DmnCanvas } from '../types';
 
 interface UseDmnViewerOptions {
-    diagramData: string;
-    onElementClick?: (elementId: string) => void;
+      diagramData: string;
+      onElementClick?: (elementId: string) => void;
 }
 
 interface UseDmnViewerResult {
-    containerRef: React.RefObject<HTMLDivElement | null>;
-    viewerRef: React.RefObject<DmnJS | null>;
-    loading: boolean;
-    error: string | null;
-    currentView: string;
+      containerRef: React.RefObject<HTMLDivElement | null>;
+      viewerRef: React.RefObject<DmnJS | null>;
+      loading: boolean;
+      error: string | null;
+      currentView: string;
 }
 
 /**
  * Hook that manages the dmn-js viewer lifecycle
  */
 export function useDmnViewer({
-    diagramData,
-    onElementClick,
+      diagramData,
+      onElementClick,
 }: UseDmnViewerOptions): UseDmnViewerResult {
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    const viewerRef = useRef<DmnJS | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [currentView, setCurrentView] = useState<string>('drd');
+      const containerRef = useRef<HTMLDivElement | null>(null);
+      const viewerRef = useRef<DmnJS | null>(null);
+      const [loading, setLoading] = useState(true);
+      const [error, setError] = useState<string | null>(null);
+      const [currentView, setCurrentView] = useState<string>('drd');
 
   // Store callback in ref to avoid re-initializing
   const onElementClickRef = useRef(onElementClick);
-    useEffect(() => {
-          onElementClickRef.current = onElementClick;
-    }, [onElementClick]);
+      useEffect(() => {
+              onElementClickRef.current = onElementClick;
+      }, [onElementClick]);
 
   // Initialize viewer and import diagram
   useEffect(() => {
-        if (!containerRef.current || !diagramData) return;
+          if (!containerRef.current || !diagramData) return;
 
                 const initViewer = async () => {
-                        setLoading(true);
-                        setError(null);
+                          setLoading(true);
+                          setError(null);
 
-                        // Capture container reference for use in async function
-                        const container = containerRef.current;
-                        if (!container) return;
+                          // Capture container reference for use in async function
+                          const container = containerRef.current;
+                          if (!container) return;
 
-                        // Clean up existing viewer
-                        if (viewerRef.current) {
-                                  viewerRef.current.destroy();
-                        }
-
-                        // Create new viewer
-                        viewerRef.current = new DmnJS({
-                                  container,
-                        });
-
-                        try {
-                                  const xml = decodeXmlData(diagramData);
-                                  await viewerRef.current.importXML(xml);
-
-                          // Get the active view and zoom to fit
-                          const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-                                  const activeView = viewerRef.current.getActiveView();
-
-                          if (activeViewer && activeView?.type === 'drd') {
-                                      // Only DRD views have a canvas service
-                                    const canvas = activeViewer.get<DmnCanvas>('canvas');
-                                      canvas.zoom('fit-viewport');
-
-                                    // Setup click handler for DRD (Decision Requirements Diagram)
-                                    const eventBus = activeViewer.get<DmnEventBus>('eventBus');
-                                      eventBus.on('element.click', (e) => {
-                                                    if (e.element.type !== 'dmn:Definitions' && onElementClickRef.current) {
-                                                                    onElementClickRef.current(e.element.id);
-                                                    }
-                                      });
+                          // Clean up existing viewer
+                          if (viewerRef.current) {
+                                      viewerRef.current.destroy();
                           }
 
-                          // Listen for view changes (switching between DRD and decision tables)
-                          const views = viewerRef.current.getViews();
-                                  if (views.length > 0) {
-                                              // Set initial view type
-                                    const activeViewState = viewerRef.current.getActiveView();
-                                              setCurrentView(activeViewState?.type || 'drd');
-                                  }
+                          // Create new viewer
+                          viewerRef.current = new DmnJS({
+                                      container,
+                          });
 
-                          // Poll for view changes (covers tab clicks and element clicks that switch views)
-                          const viewCheckInterval = setInterval(() => {
-                                      const activeViewState = viewerRef.current?.getActiveView();
-                                      if (activeViewState) {
-                                                    setCurrentView((prev) => {
-                                                                    if (prev !== activeViewState.type) {
-                                                                                      return activeViewState.type;
-                                                                    }
-                                                                    return prev;
-                                                    });
+                          try {
+                                      const xml = decodeXmlData(diagramData);
+                                      await viewerRef.current.importXML(xml);
+
+                            // Get the active view and zoom to fit
+                            const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
+                                      const activeView = viewerRef.current.getActiveView();
+
+                            if (activeViewer && activeView?.type === 'drd') {
+                                          const canvas = activeViewer.get<DmnCanvas>('canvas');
+                                          canvas.zoom('fit-viewport');
+
+                                        // Setup click handler for DRD (Decision Requirements Diagram)
+                                        const eventBus = activeViewer.get<DmnEventBus>('eventBus');
+                                          eventBus.on('element.click', (e) => {
+                                                          if (e.element.type !== 'dmn:Definitions' && onElementClickRef.current) {
+                                                                            onElementClickRef.current(e.element.id);
+                                                          }
+                                          });
+                            }
+
+                            // Listen for view changes (switching between DRD and decision tables)
+                            const views = viewerRef.current.getViews();
+                                      if (views.length > 0) {
+                                                    // Set initial view type
+                                        const activeView = viewerRef.current.getActiveView();
+                                                    setCurrentView(activeView?.type || 'drd');
                                       }
-                          }, 200);
 
-                          // Store interval for cleanup
-                          (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
+                            // Poll for view changes (covers tab clicks and element clicks that switch views)
+                            const viewCheckInterval = setInterval(() => {
+                                          const activeView = viewerRef.current?.getActiveView();
+                                          if (activeView) {
+                                                          setCurrentView((prev) => {
+                                                                            if (prev !== activeView.type) {
+                                                                                                return activeView.type;
+                                                                            }
+                                                                            return prev;
+                                                          });
+                                          }
+                            }, 200);
 
-                          setLoading(false);
-                                  setError(null);
-                        } catch (err) {
-                                  console.error('Failed to import DMN diagram:', err);
-                                  setError('Failed to load diagram');
-                                  setLoading(false);
-                        }
+                            // Store interval for cleanup
+                            (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
+
+                            setLoading(false);
+                                      setError(null);
+                          } catch (err) {
+                                      console.error('Failed to import DMN diagram:', err);
+                                      setError('Failed to load diagram');
+                                      setLoading(false);
+                          }
                 };
 
                 void initViewer();
 
                 return () => {
-                        if (viewerRef.current) {
-                                  // Clear view check interval
-                          const interval = (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval;
-                                  if (interval) {
-                                              clearInterval(interval);
-                                  }
-                                  viewerRef.current.destroy();
-                                  viewerRef.current = null;
-                        }
+                          if (viewerRef.current) {
+                                      // Clear view check interval
+                            const interval = (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval;
+                                      if (interval) {
+                                                    clearInterval(interval);
+                                      }
+                                      viewerRef.current.destroy();
+                                      viewerRef.current = null;
+                          }
                 };
   }, [diagramData]);
 
   return {
-        containerRef,
-        viewerRef,
-        loading,
-        error,
-        currentView,
+          containerRef,
+          viewerRef,
+          loading,
+          error,
+          currentView,
   };
 }


### PR DESCRIPTION
## Problem

Navigating to `/decision-definitions/:id` throws an **"Unexpected Application Error"** with the message:

```
Error: No provider for "canvas"! (Resolving: canvas)
```

This crash happens because `DmnViewer` calls `activeViewer.get('canvas')` unconditionally after `importXML`. In dmn-js, the `canvas` service is only available in **DRD (Decision Requirements Diagram)** views. Decision table viewers and literal expression viewers do **not** register a `canvas` provider — so calling `.get('canvas')` on them throws a DI resolution error that bubbles up and crashes the entire page.

## Root Cause

Three places in the `DmnViewer` component family called `activeViewer.get('canvas')` without first checking the active view type:

1. **`useDmnViewer.ts`** (primary crash site) — called unconditionally right after `importXML`, including the `eventBus` click handler setup which is also DRD-only
2. 2. **`DmnViewer.tsx`** — called in the responsive-resize `useEffect` on every `responsiveHeight` change
3. 3. **`useDmnOverlays.tsx`** — called inside `zoomToFitWithOverlays`, which was indirectly guarded but lacked a defensive try-catch
## Fix

Added view type guards before every `activeViewer.get('canvas')` call:

- **`useDmnViewer.ts`**: Wrap canvas + eventBus setup in `if (activeViewer && activeView?.type === 'drd')`
- - **`DmnViewer.tsx`**: Add early return `if (currentView !== 'drd') return` in the resize effect (uses the already-tracked `currentView` state, also added to the effect dependency array)
- - **`useDmnOverlays.tsx`**: Wrap the `canvas.get(...)` call in `zoomToFitWithOverlays` in a try-catch so any unexpected view type mismatches are handled gracefully
## Testing

- Navigate to `/decision-definitions/:id` — page should load without crashing
- - DMN diagram should render and zoom to fit
- - Switching to decision table view and back should work correctly