### PR TITLE
fix: resolve "No provider for canvas" crash on decision-definition detail page

### DIFF
--- a/src/components/DmnEditor/hooks/useDmnEditor.ts
+++ b/src/components/DmnEditor/hooks/useDmnEditor.ts
@@ -4,7 +4,7 @@ import {
   DmnPropertiesPanelModule,
   DmnPropertiesProviderModule,
 } from 'dmn-js-properties-panel';
-import type { DmnCanvas, DmnEventBus, DmnViewer } from '../types';
+import type { DmnActiveView, DmnCanvas, DmnEventBus, DmnViewer } from '../types';
 import { emptyDiagram } from '../utils.ts';
 
 interface UseDmnEditorOptions {
@@ -52,13 +52,10 @@ export function useDmnEditor({
     try {
       await modelerRef.current.importXML(xml);
       const activeViewer = modelerRef.current.getActiveViewer() as DmnViewer | null;
-      if (activeViewer) {
-        try {
-          const canvas = activeViewer.get<DmnCanvas>('canvas');
-          canvas.zoom('fit-viewport');
-        } catch {
-          // Decision table viewers have no canvas service — skip fit-viewport
-        }
+      const activeView = modelerRef.current.getActiveView() as DmnActiveView | null;
+      if (activeViewer && activeView?.type === 'drd') {
+        const canvas = activeViewer.get<DmnCanvas>('canvas');
+        canvas.zoom('fit-viewport');
       }
       setLoading(false);
     } catch (err) {
@@ -146,13 +143,10 @@ export function useDmnEditor({
         setupChangeListener();
 
         const activeViewer = modeler.getActiveViewer() as DmnViewer | null;
-        if (activeViewer) {
-          try {
-            const canvas = activeViewer.get<DmnCanvas>('canvas');
-            canvas.zoom('fit-viewport');
-          } catch {
-            // Decision table viewers have no canvas service — skip fit-viewport
-          }
+        const activeView = modeler.getActiveView() as DmnActiveView | null;
+        if (activeViewer && activeView?.type === 'drd') {
+          const canvas = activeViewer.get<DmnCanvas>('canvas');
+          canvas.zoom('fit-viewport');
         }
         setLoading(false);
       } catch (err) {
@@ -188,13 +182,10 @@ export function useDmnEditor({
         const xmlToLoad = initialXml || emptyDiagram();
         await modelerRef.current.importXML(xmlToLoad);
         const activeViewer = modelerRef.current.getActiveViewer() as DmnViewer | null;
-        if (activeViewer) {
-          try {
-            const canvas = activeViewer.get<DmnCanvas>('canvas');
-            canvas.zoom('fit-viewport');
-          } catch {
-            // Decision table viewers have no canvas service — skip fit-viewport
-          }
+        const activeView = modelerRef.current.getActiveView() as DmnActiveView | null;
+        if (activeViewer && activeView?.type === 'drd') {
+          const canvas = activeViewer.get<DmnCanvas>('canvas');
+          canvas.zoom('fit-viewport');
         }
         setLoading(false);
       } catch (err) {

--- a/src/components/DmnEditor/hooks/useDmnEditor.ts
+++ b/src/components/DmnEditor/hooks/useDmnEditor.ts
@@ -53,8 +53,12 @@ export function useDmnEditor({
       await modelerRef.current.importXML(xml);
       const activeViewer = modelerRef.current.getActiveViewer() as DmnViewer | null;
       if (activeViewer) {
-        const canvas = activeViewer.get<DmnCanvas>('canvas');
-        canvas.zoom('fit-viewport');
+        try {
+          const canvas = activeViewer.get<DmnCanvas>('canvas');
+          canvas.zoom('fit-viewport');
+        } catch {
+          // Decision table viewers have no canvas service — skip fit-viewport
+        }
       }
       setLoading(false);
     } catch (err) {
@@ -143,8 +147,12 @@ export function useDmnEditor({
 
         const activeViewer = modeler.getActiveViewer() as DmnViewer | null;
         if (activeViewer) {
-          const canvas = activeViewer.get<DmnCanvas>('canvas');
-          canvas.zoom('fit-viewport');
+          try {
+            const canvas = activeViewer.get<DmnCanvas>('canvas');
+            canvas.zoom('fit-viewport');
+          } catch {
+            // Decision table viewers have no canvas service — skip fit-viewport
+          }
         }
         setLoading(false);
       } catch (err) {
@@ -181,8 +189,12 @@ export function useDmnEditor({
         await modelerRef.current.importXML(xmlToLoad);
         const activeViewer = modelerRef.current.getActiveViewer() as DmnViewer | null;
         if (activeViewer) {
-          const canvas = activeViewer.get<DmnCanvas>('canvas');
-          canvas.zoom('fit-viewport');
+          try {
+            const canvas = activeViewer.get<DmnCanvas>('canvas');
+            canvas.zoom('fit-viewport');
+          } catch {
+            // Decision table viewers have no canvas service — skip fit-viewport
+          }
         }
         setLoading(false);
       } catch (err) {

--- a/src/components/DmnEditor/types.ts
+++ b/src/components/DmnEditor/types.ts
@@ -28,3 +28,7 @@ export interface DmnEventBus {
 export interface DmnViewer {
   get: <T = unknown>(name: string) => T;
 }
+
+export interface DmnActiveView {
+  type: string;
+}

--- a/src/components/DmnViewer/DmnViewer.tsx
+++ b/src/components/DmnViewer/DmnViewer.tsx
@@ -93,7 +93,7 @@ export const DmnViewer = ({
       (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
     );
     if (hasOverlaysWithData) return;
-        if (currentView !== 'drd') return;
+    if (currentView !== 'drd') return;
 
     const activeViewer = viewerRef.current.getActiveViewer();
     if (!activeViewer) return;

--- a/src/components/DmnViewer/DmnViewer.tsx
+++ b/src/components/DmnViewer/DmnViewer.tsx
@@ -93,6 +93,7 @@ export const DmnViewer = ({
       (o) => o.evaluated && ((o.inputs && o.inputs.length > 0) || (o.outputs && o.outputs.length > 0))
     );
     if (hasOverlaysWithData) return;
+        if (currentView !== 'drd') return;
 
     const activeViewer = viewerRef.current.getActiveViewer();
     if (!activeViewer) return;
@@ -109,7 +110,7 @@ export const DmnViewer = ({
     }, 100);
 
     return () => clearTimeout(timeoutId);
-  }, [responsiveHeight, loading, overlays, viewerRef]);
+  }, [responsiveHeight, loading, overlays, viewerRef, currentView]);
 
   return (
     <Box sx={{ position: 'relative', width: '100%', height: responsiveHeight, minHeight }}>

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -62,8 +62,8 @@ export function useDmnViewer({
         await viewerRef.current.importXML(xml);
 
         // Get the active view and zoom to fit
-        const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-        const activeView = viewerRef.current.getActiveView();
+        const activeViewer = viewerRef.current?.getActiveViewer() as DmnActiveViewer | null;
+        const activeView = viewerRef.current?.getActiveView();
         if (activeViewer && activeView?.type === 'drd') {
           const canvas = activeViewer.get<DmnCanvas>('canvas');
           canvas.zoom('fit-viewport');
@@ -78,20 +78,20 @@ export function useDmnViewer({
         }
 
         // Listen for view changes (switching between DRD and decision tables)
-        const views = viewerRef.current.getViews();
-        if (views.length > 0) {
+        const views = viewerRef.current?.getViews();
+        if (views && views.length > 0) {
           // Set initial view type
-          const activeView = viewerRef.current.getActiveView();
-          setCurrentView(activeView?.type || 'drd');
+          const initialView = viewerRef.current?.getActiveView();
+          setCurrentView(initialView?.type || 'drd');
         }
 
         // Poll for view changes (covers tab clicks and element clicks that switch views)
         const viewCheckInterval = setInterval(() => {
-          const activeView = viewerRef.current?.getActiveView();
-          if (activeView) {
+          const currentActiveView = viewerRef.current?.getActiveView();
+          if (currentActiveView) {
             setCurrentView((prev) => {
-              if (prev !== activeView.type) {
-                return activeView.type;
+              if (prev !== currentActiveView.type) {
+                return currentActiveView.type;
               }
               return prev;
             });
@@ -99,7 +99,7 @@ export function useDmnViewer({
         }, 200);
 
         // Store interval for cleanup
-        (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
+        (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })?._viewCheckInterval = viewCheckInterval;
 
         setLoading(false);
         setError(null);

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -63,7 +63,8 @@ export function useDmnViewer({
 
         // Get the active view and zoom to fit
         const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-        if (activeViewer) {
+                const activeView = viewerRef.current.getActiveView();
+                if (activeViewer && activeView?.type === 'drd') {
           const canvas = activeViewer.get<DmnCanvas>('canvas');
           canvas.zoom('fit-viewport');
 

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -63,8 +63,8 @@ export function useDmnViewer({
 
         // Get the active view and zoom to fit
         const activeViewer = viewerRef.current.getActiveViewer() as DmnActiveViewer | null;
-                const activeView = viewerRef.current.getActiveView();
-                if (activeViewer && activeView?.type === 'drd') {
+        const activeView = viewerRef.current.getActiveView();
+        if (activeViewer && activeView?.type === 'drd') {
           const canvas = activeViewer.get<DmnCanvas>('canvas');
           canvas.zoom('fit-viewport');
 

--- a/src/components/DmnViewer/hooks/useDmnViewer.ts
+++ b/src/components/DmnViewer/hooks/useDmnViewer.ts
@@ -99,7 +99,9 @@ export function useDmnViewer({
         }, 200);
 
         // Store interval for cleanup
-        (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })?._viewCheckInterval = viewCheckInterval;
+        if (viewerRef.current) {
+          (viewerRef.current as unknown as { _viewCheckInterval?: ReturnType<typeof setInterval> })._viewCheckInterval = viewCheckInterval;
+        }
 
         setLoading(false);
         setError(null);


### PR DESCRIPTION
## Problem

Navigating to `/decision-definitions/:id` crashes with:

```
Error: No provider for "canvas"! (Resolving: canvas)
```

In dmn-js, the `canvas` service only exists in **DRD (Decision Requirements Diagram)** views. Decision table and literal expression viewers do not register it. Calling `activeViewer.get('canvas')` unconditionally throws a DI resolution error that crashes the entire page.

## Changes

**`useDmnViewer.ts`** — Added `const activeView = viewerRef.current.getActiveView()` after `importXML` and changed `if (activeViewer)` to `if (activeViewer && activeView?.type === 'drd')`. This guards both the `canvas.zoom()` call and the `eventBus` click handler setup (also DRD-only) so they are skipped for decision table / literal expression views.

**`DmnViewer.tsx`** — Added `if (currentView !== 'drd') return` early return in the responsive-resize `useEffect` before calling `activeViewer.get('canvas')`, and added `currentView` to the effect dependency array.

## Testing

- Navigate to `/decision-definitions/:id` — page loads without crashing
- - DMN diagram renders and zooms to fit
- - Switching between DRD and decision table views works correctly