### PR TITLE
Fix/751 process instance diagram doubles element statistics when the root instance is a subprocess

### DIFF
--- a/e2e/pages/process-instances/statistics.spec.ts
+++ b/e2e/pages/process-instances/statistics.spec.ts
@@ -6,6 +6,7 @@ import { test, expect, type ConsoleMessage } from '@playwright/test';
 //   - one unresolved incident on task-a                  → incidentCount: 1 on task-a
 // This gives both badge types (.running-badge and .failed-badge) on the same element.
 const STATS_INSTANCE_KEY = '3100000000000000250';
+const SUBPROCESS_ROOT_STATS_INSTANCE_KEY = '3100000000000000251';
 
 test.describe('Process Instance Detail - Statistics Overlays', () => {
   test.beforeEach(async ({ page }) => {
@@ -58,6 +59,19 @@ test.describe('Process Instance Detail - Statistics Overlays', () => {
 
     page.off('console', handler);
     expect(validationErrors, `MSW schema violations: ${validationErrors.join('\n')}`).toHaveLength(0);
+  });
+});
+
+test.describe('Process Instance Detail - Subprocess Root Statistics', () => {
+  test('should not double element statistics when the viewed root instance is a subprocess', async ({ page }) => {
+    await page.goto(`/process-instances/${SUBPROCESS_ROOT_STATS_INSTANCE_KEY}`);
+    await expect(page.getByText('Instance Details')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.bjs-container')).toBeVisible({ timeout: 10000 });
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(500);
+
+    // The subprocess root has exactly one active instance on task-a.
+    await expect(page.locator('.running-badge').first()).toHaveText('1', { timeout: 10000 });
   });
 });
 

--- a/src/mocks/data/bpmn/showcase-process.ts
+++ b/src/mocks/data/bpmn/showcase-process.ts
@@ -378,6 +378,20 @@ export const instances: MockProcessInstance[] = [
     1,
     'task-a'
   ),
+  // Dedicated subprocess-root instance for statistics aggregation regression testing.
+  // The synthetic parent key keeps this fixture out of root-instance list results.
+  {
+    ...createInstance(
+      '3100000000000000251',
+      hoursAgo(3),
+      'active',
+      { customerId: 'CUST-STATS-002', customerName: 'Subprocess Statistics Test User', loanAmount: 25000 },
+      1,
+      'task-a'
+    ),
+    processType: 'subprocess',
+    parentProcessInstanceKey: '3100000000000000999',
+  },
 ];
 
 export const incidents: MockIncident[] = [

--- a/src/mocks/handlers/processDefinitions.ts
+++ b/src/mocks/handlers/processDefinitions.ts
@@ -35,6 +35,7 @@ function computeStatisticsForDefinition(processDefinitionKey: string) {
       completed: completedCount,
       terminated: terminatedCount,
       failed: failedCount,
+      withIncident: new Set(defIncidents.map((incident) => incident.processInstanceKey)).size,
     },
     incidentCounts: {
       total: incidents.filter((i) => i.processDefinitionKey === processDefinitionKey).length,

--- a/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
@@ -237,7 +237,7 @@ export const useInstanceData = (
   const fetchSubprocessStats = useCallback(
     async (root: ProcessInstanceNode) => {
       const subprocessNodes = collectAllNodes(root).filter(
-        (n) => n.instance.processType === 'subprocess',
+        (n) => !n.isRoot && n.instance.processType === 'subprocess',
       );
 
       if (subprocessNodes.length === 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate BPMN statistics badges when viewing subprocess root instances.
  * Improved subprocess statistics aggregation by excluding the root process node.
  * Added incident-related counts to process definition statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->