### PR TITLE
fix(#750): propagate child process incidents to parent diagram

### DIFF
--- a/e2e/pages/process-instances/child-processes.spec.ts
+++ b/e2e/pages/process-instances/child-processes.spec.ts
@@ -5,6 +5,8 @@ const parentInstanceKey = '3100000000000000066';
 // Child process instances spawned by the parent above
 const childInstanceKey1 = '3100000000000000200'; // active child
 const childInstanceKey2 = '3100000000000000202'; // completed child
+const nestedIncidentRootKey = '3100000000000000290';
+const nestedIncidentCalledKey = '3100000000000000292';
 
 test.describe('Process Instance Detail - Child Processes Tab', () => {
   test.beforeEach(async ({ page }) => {
@@ -84,6 +86,20 @@ test.describe('Process Instance Detail - Child Processes Tab', () => {
     // Should navigate to the child instance detail page
     await expect(page).toHaveURL(new RegExp(`/process-instances/${childInstanceKey1}`));
     await expect(page.getByText('Instance Details')).toBeVisible({ timeout: 10000 });
+  });
+});
+
+test.describe('Process Instance Detail - Called Process Incidents', () => {
+  test('should display the direct unresolved incident count for a called process', async ({ page }) => {
+    await page.goto(`/process-instances/${nestedIncidentRootKey}`);
+    await expect(page.getByText('Instance Details')).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('tab', { name: /Called Processes/i }).click();
+    await expect(page.getByRole('columnheader', { name: 'Incidents' })).toBeVisible();
+
+    const calledProcessRow = page.getByRole('row').filter({ hasText: nestedIncidentCalledKey });
+    await expect(calledProcessRow).toBeVisible();
+    await expect(calledProcessRow.getByText('1', { exact: true })).toBeVisible();
   });
 });
 

--- a/e2e/pages/process-instances/statistics.spec.ts
+++ b/e2e/pages/process-instances/statistics.spec.ts
@@ -7,6 +7,8 @@ import { test, expect, type ConsoleMessage } from '@playwright/test';
 // This gives both badge types (.running-badge and .failed-badge) on the same element.
 const STATS_INSTANCE_KEY = '3100000000000000250';
 const SUBPROCESS_ROOT_STATS_INSTANCE_KEY = '3100000000000000251';
+const NESTED_INCIDENT_ROOT_KEY = '3100000000000000290';
+const NESTED_INCIDENT_CALLED_KEY = '3100000000000000292';
 
 test.describe('Process Instance Detail - Statistics Overlays', () => {
   test.beforeEach(async ({ page }) => {
@@ -72,6 +74,34 @@ test.describe('Process Instance Detail - Subprocess Root Statistics', () => {
 
     // The subprocess root has exactly one active instance on task-a.
     await expect(page.locator('.running-badge').first()).toHaveText('1', { timeout: 10000 });
+  });
+});
+
+test.describe('Process Instance Detail - Nested Incident Overlays', () => {
+  test('propagates called-process incidents without additional API calls', async ({ page }) => {
+    const calledProcessDatasetRequests: string[] = [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (
+        url.includes(`/process-instances/${NESTED_INCIDENT_CALLED_KEY}/incidents`) ||
+        url.includes(`/process-instances/${NESTED_INCIDENT_CALLED_KEY}/statistics`)
+      ) {
+        calledProcessDatasetRequests.push(url);
+      }
+    });
+
+    await page.goto(`/process-instances/${NESTED_INCIDENT_ROOT_KEY}`);
+    await expect(page.getByText('Instance Details')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.bjs-container')).toBeVisible({ timeout: 10000 });
+
+    // The direct incident count from the called-process child is projected onto
+    // both its call activity and the containing multi-instance subprocess.
+    const failedBadges = page.locator('.failed-badge');
+    await expect(failedBadges).toHaveCount(2, { timeout: 10000 });
+    await expect(page.locator('[data-container-id="CallActivity"] .failed-badge')).toHaveText('1');
+    await expect(page.locator('[data-container-id="Activity_044v303"] .failed-badge')).toHaveText('1');
+
+    expect(calledProcessDatasetRequests).toEqual([]);
   });
 });
 

--- a/src/mocks/data/bpmn/index.ts
+++ b/src/mocks/data/bpmn/index.ts
@@ -62,6 +62,7 @@ import * as simpleUserTaskV2 from './simple-user-task_v2';
 import * as longTaskChainV2 from './long-task-chain_v2';
 // Pagination test fixture
 import * as multiInstancePagination from './multi-instance-pagination';
+import * as multiInstanceCallActivityIncident from './multi-instance-call-activity-incident';
 
 // Export individual process modules for direct access
 export {
@@ -121,6 +122,7 @@ export {
   simpleUserTaskV2,
   longTaskChainV2,
   multiInstancePagination,
+  multiInstanceCallActivityIncident,
 };
 
 // Aggregate all definitions
@@ -181,6 +183,7 @@ export const allDefinitions: MockProcessDefinition[] = [
   simpleUserTaskV2.definition,
   longTaskChainV2.definition,
   multiInstancePagination.definition,
+  multiInstanceCallActivityIncident.definition,
 ];
 
 // Aggregate all instances
@@ -242,6 +245,7 @@ export const allInstances: MockProcessInstance[] = [
   ...longTaskChainV2.instances,
   // Pagination test fixture
   ...multiInstancePagination.instances,
+  ...multiInstanceCallActivityIncident.instances,
 ];
 
 // Aggregate all incidents
@@ -303,4 +307,5 @@ export const allIncidents: MockIncident[] = [
   ...longTaskChainV2.incidents,
   // Pagination test fixture
   ...multiInstancePagination.incidents,
+  ...multiInstanceCallActivityIncident.incidents,
 ];

--- a/src/mocks/data/bpmn/multi-instance-call-activity-incident.bpmn
+++ b/src/mocks/data/bpmn/multi-instance-call-activity-incident.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_MultiInstanceCallIncident" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="multi_instance_call_incident" name="Multi-instance call activity incident" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Activity_044v303" />
+    <bpmn:subProcess id="Activity_044v303" name="Multi-instance subprocess">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics />
+      <bpmn:startEvent id="NestedStartEvent">
+        <bpmn:outgoing>NestedFlow_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="NestedFlow_1" sourceRef="NestedStartEvent" targetRef="CallActivity" />
+      <bpmn:callActivity id="CallActivity" name="Called process">
+        <bpmn:incoming>NestedFlow_1</bpmn:incoming>
+        <bpmn:outgoing>NestedFlow_2</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:sequenceFlow id="NestedFlow_2" sourceRef="CallActivity" targetRef="NestedEndEvent" />
+      <bpmn:endEvent id="NestedEndEvent">
+        <bpmn:incoming>NestedFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_044v303" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="multi_instance_call_incident">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_044v303_di" bpmnElement="Activity_044v303" isExpanded="true">
+        <dc:Bounds x="270" y="140" width="430" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NestedStartEvent_di" bpmnElement="NestedStartEvent">
+        <dc:Bounds x="312" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_di" bpmnElement="CallActivity">
+        <dc:Bounds x="430" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NestedEndEvent_di" bpmnElement="NestedEndEvent">
+        <dc:Bounds x="612" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="782" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="240" />
+        <di:waypoint x="270" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="NestedFlow_1_di" bpmnElement="NestedFlow_1">
+        <di:waypoint x="348" y="240" />
+        <di:waypoint x="430" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="NestedFlow_2_di" bpmnElement="NestedFlow_2">
+        <di:waypoint x="530" y="240" />
+        <di:waypoint x="612" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="700" y="240" />
+        <di:waypoint x="782" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/mocks/data/bpmn/multi-instance-call-activity-incident.ts
+++ b/src/mocks/data/bpmn/multi-instance-call-activity-incident.ts
@@ -1,0 +1,110 @@
+import type { MockIncident, MockProcessDefinition, MockProcessInstance } from '../types';
+import bpmnData from './multi-instance-call-activity-incident.bpmn?raw';
+
+export const ROOT_INSTANCE_KEY = '3100000000000000290';
+export const MULTI_INSTANCE_KEY = '3100000000000000291';
+export const CALLED_INSTANCE_KEY = '3100000000000000292';
+
+export const definition: MockProcessDefinition = {
+  key: '3000000000000000090',
+  version: 1,
+  bpmnProcessId: 'multi_instance_call_incident',
+  bpmnProcessName: 'Multi-instance call activity incident',
+  bpmnResourceName: 'multi-instance-call-activity-incident.bpmn',
+  bpmnData,
+  createdAt: '2026-01-01T09:00:00.000Z',
+};
+
+export const instances: MockProcessInstance[] = [
+  {
+    key: ROOT_INSTANCE_KEY,
+    processDefinitionKey: definition.key,
+    bpmnProcessId: definition.bpmnProcessId,
+    createdAt: '2026-01-01T10:00:00.000Z',
+    state: 'active',
+    processType: 'default',
+    variables: { items: ['one'] },
+    activeElementInstances: [
+      { key: '3100000000000000293', elementId: 'Activity_044v303', elementType: 'subProcess' },
+    ],
+    history: [
+      {
+        key: '3100000000000000294',
+        elementId: 'StartEvent_1',
+        elementType: 'startEvent',
+        state: 'completed',
+        startedAt: '2026-01-01T10:00:00.000Z',
+        completedAt: '2026-01-01T10:00:10.000Z',
+      },
+      {
+        key: '3100000000000000295',
+        elementId: 'Activity_044v303',
+        elementType: 'subProcess',
+        state: 'active',
+        startedAt: '2026-01-01T10:00:30.000Z',
+      },
+    ],
+    partition: 1,
+  },
+  {
+    key: MULTI_INSTANCE_KEY,
+    processDefinitionKey: definition.key,
+    bpmnProcessId: definition.bpmnProcessId,
+    createdAt: '2026-01-01T10:01:00.000Z',
+    state: 'active',
+    processType: 'multiInstance',
+    variables: { item: 'one' },
+    activeElementInstances: [
+      { key: '3100000000000000296', elementId: 'CallActivity', elementType: 'callActivity' },
+    ],
+    history: [
+      {
+        key: '3100000000000000297',
+        elementId: 'NestedStartEvent',
+        elementType: 'startEvent',
+        state: 'completed',
+        startedAt: '2026-01-01T10:01:00.000Z',
+        completedAt: '2026-01-01T10:01:10.000Z',
+      },
+      {
+        key: '3100000000000000298',
+        elementId: 'CallActivity',
+        elementType: 'callActivity',
+        state: 'active',
+        startedAt: '2026-01-01T10:02:00.000Z',
+      },
+    ],
+    partition: 1,
+    parentProcessInstanceKey: ROOT_INSTANCE_KEY,
+  },
+  {
+    key: CALLED_INSTANCE_KEY,
+    processDefinitionKey: '3000000000000000091',
+    bpmnProcessId: 'called_incident_process',
+    createdAt: '2026-01-01T10:03:00.000Z',
+    state: 'active',
+    processType: 'callActivity',
+    variables: {},
+    activeElementInstances: [
+      { key: '3100000000000000299', elementId: 'CalledServiceTask', elementType: 'serviceTask' },
+    ],
+    history: [],
+    partition: 1,
+    parentProcessInstanceKey: MULTI_INSTANCE_KEY,
+  },
+];
+
+export const incidents: MockIncident[] = [
+  {
+    key: '4100000000000000290',
+    elementInstanceKey: '3100000000000000299',
+    elementId: 'CalledServiceTask',
+    processInstanceKey: CALLED_INSTANCE_KEY,
+    processDefinitionKey: '3000000000000000091',
+    bpmnProcessId: 'called_incident_process',
+    errorType: 'JOB_NO_RETRIES',
+    message: 'Called service task failed',
+    createdAt: '2026-01-01T10:04:00.000Z',
+    executionToken: '3100000000000000299',
+  },
+];

--- a/src/mocks/handlers/processInstances.ts
+++ b/src/mocks/handlers/processInstances.ts
@@ -92,6 +92,7 @@ function transformInstance(pi: (typeof processInstances)[0]) {
     state: pi.state,
     variables: pi.variables,
     processType: pi.processType ?? 'default',
+    incidentCount: getIncidentsByProcessInstanceKey(pi.key).filter((incident) => !incident.resolvedAt).length,
     ...(pi.parentProcessInstanceKey ? { parentProcessInstanceKey: pi.parentProcessInstanceKey } : {}),
     activeElementInstances: pi.activeElementInstances.map((ei) => ({
       elementInstanceKey: ei.key,

--- a/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
@@ -130,6 +130,40 @@ function collectAllNodes(root: ProcessInstanceNode): ProcessInstanceNode[] {
   return result;
 }
 
+/**
+ * Project direct incidents from called processes onto the elements that lead
+ * to them in the currently displayed parent diagram. Child list responses
+ * already contain incidentCount, so this does not require another API call.
+ */
+function projectCalledProcessIncidents(
+  root: ProcessInstanceNode | null,
+): ElementStatistics | undefined {
+  if (!root) return undefined;
+
+  const projected: ElementStatistics = {};
+  for (const node of collectAllNodes(root)) {
+    if (node.isRoot || node.instance.processType !== 'callActivity') continue;
+
+    const incidentCount = node.instance.incidentCount ?? 0;
+    if (incidentCount <= 0) continue;
+
+    // A path can contain the same BPMN element more than once in nested loops.
+    // Count this called instance only once per affected diagram element.
+    for (const elementId of new Set(node.callPath)) {
+      const counts = projected[elementId] ?? {
+        activeCount: 0,
+        incidentCount: 0,
+        completedCount: 0,
+        terminatedCount: 0,
+      };
+      counts.incidentCount += incidentCount;
+      projected[elementId] = counts;
+    }
+  }
+
+  return Object.keys(projected).length > 0 ? projected : undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -426,22 +460,40 @@ export const useInstanceData = (
     },
   );
 
+  const calledProcessIncidentStatistics = useMemo(
+    () => projectCalledProcessIncidents(instanceTree),
+    [instanceTree],
+  );
+
   const elementStatistics = useMemo(() => {
     const base = transformStatisticsToElementStatistics(rawElementStatistics);
-    if (!subprocessElementStatistics) return base;
-    if (!base) return subprocessElementStatistics;
-    const merged: ElementStatistics = { ...base };
-    for (const [elementId, counts] of Object.entries(subprocessElementStatistics)) {
-      if (!merged[elementId]) merged[elementId] = { activeCount: 0, incidentCount: 0, completedCount: 0, terminatedCount: 0 };
-      merged[elementId] = {
-        activeCount: merged[elementId].activeCount + counts.activeCount,
-        incidentCount: merged[elementId].incidentCount + counts.incidentCount,
-        completedCount: (merged[elementId].completedCount ?? 0) + (counts.completedCount ?? 0),
-        terminatedCount: (merged[elementId].terminatedCount ?? 0) + (counts.terminatedCount ?? 0),
-      };
+    const additionalStatistics = [
+      subprocessElementStatistics,
+      calledProcessIncidentStatistics,
+    ].filter((statistics): statistics is ElementStatistics => statistics !== undefined);
+
+    if (additionalStatistics.length === 0) return base;
+
+    const merged: ElementStatistics = {};
+    for (const statistics of [base, ...additionalStatistics]) {
+      if (!statistics) continue;
+      for (const [elementId, counts] of Object.entries(statistics)) {
+        const current = merged[elementId] ?? {
+          activeCount: 0,
+          incidentCount: 0,
+          completedCount: 0,
+          terminatedCount: 0,
+        };
+        merged[elementId] = {
+          activeCount: current.activeCount + counts.activeCount,
+          incidentCount: current.incidentCount + counts.incidentCount,
+          completedCount: (current.completedCount ?? 0) + (counts.completedCount ?? 0),
+          terminatedCount: (current.terminatedCount ?? 0) + (counts.terminatedCount ?? 0),
+        };
+      }
     }
     return merged;
-  }, [rawElementStatistics, subprocessElementStatistics]);
+  }, [rawElementStatistics, subprocessElementStatistics, calledProcessIncidentStatistics]);
 
   // ── Pagination effects — update the current page in the tree ─────────────
   // These only fire after the initial load completes (guard via ref).

--- a/src/pages/ProcessInstanceDetail/tabs/ChildProcessesTab.tsx
+++ b/src/pages/ProcessInstanceDetail/tabs/ChildProcessesTab.tsx
@@ -6,6 +6,7 @@ import { Box } from '@mui/material';
 import { ClientSideDataTable, type Column, type DataTableSection } from '@components/DataTable';
 import { StateBadge } from '@components/StateBadge';
 import { MonoText } from '@components/MonoText';
+import { NumericBadge } from '@components/NumericBadge';
 import type { ProcessInstance } from '../types';
 import type { ProcessInstanceNode } from '../types/tree';
 import { formatDate } from '@/components/DiagramDetailLayout/utils';
@@ -70,6 +71,13 @@ export const ChildProcessesTab = ({
         render: (row) => (
           <StateBadge state={row.state} label={t(`processes:states.${row.state}`)} />
         ),
+      },
+      {
+        id: 'incidentCount',
+        label: t('processes:fields.incidents'),
+        width: 100,
+        align: 'center',
+        render: (row) => <NumericBadge value={row.incidentCount ?? 0} color="error" />,
       },
       {
         id: 'processType',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unresolved incident counts to process instance data payloads.
  * Display incident counts from called processes directly on the related call activity elements in process instance diagrams.
  * Projected called-process incident counts onto multi-instance subprocess activities, including nested scenarios.
  * Updated the “Called Processes” tab to include an Incidents column with error badges.
* **Bug Fixes**
  * Improved incident overlay behavior to ensure accurate badges without triggering unnecessary additional statistics/incident requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->