### PR TITLE
fix(#779): paginated getHistory - page size 1000 maximum items 10 000

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: ZenBPM OpenAPI
   description: REST API for ZenBPM
-  version: 1.5.0
+  version: 1.6.0
   contact:
     name: API Support
     email: info@pbinitiative.org
@@ -96,6 +96,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
     get:
       operationId: getDmnResourceDefinitions
@@ -189,6 +195,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /dmn-resource-definitions/{dmnResourceDefinitionKey}:
     get:
@@ -247,6 +255,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /decision-definitions/{decisionId}/evaluate:
     post:
@@ -284,6 +294,7 @@ paths:
                   type: string
                 variables:
                   type: object
+                  nullable: true
             example:
               bindingType: "latest"
               variables:
@@ -358,6 +369,12 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to redirect request to responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /decision-instances:
     get:
@@ -481,6 +498,8 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to collect data from responsible nodes"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /decision-instances/{decisionInstanceKey}:
     get:
@@ -563,6 +582,8 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to collect data from responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-definitions:
     post:
@@ -582,10 +603,10 @@ paths:
                 resource:
                   type: string
                   format: binary
-                  description: BPMN process definition file (.bpmn format only, max 4MB)
+                  description: BPMN process definition file (.bpmn format only, size limited by httpServer.maxRequestBodyBytes, 10 MiB by default)
             encoding:
               resource:
-                contentType: application/octet-stream
+                contentType: application/octet-stream, application/xml
       responses:
         201:
           description: Process definition deployed
@@ -645,6 +666,12 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to redirect request to responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
     get:
       operationId: getProcessDefinitions
       summary: Get list of process definitions
@@ -733,6 +760,8 @@ paths:
               example:
                 code: "INTERNAL_SERVER_ERROR"
                 message: "An unexpected error occurred while retrieving process definitions"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-definitions/{processDefinitionKey}:
     get:
@@ -793,6 +822,8 @@ paths:
               example:
                 code: "INTERNAL_SERVER_ERROR"
                 message: "An unexpected error occurred while retrieving the process definition"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-definitions/{processDefinitionKey}/statistics:
     get:
@@ -869,6 +900,8 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to redirect request to responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-definitions/statistics:
     get:
@@ -996,6 +1029,8 @@ paths:
               example:
                 code: "BAD_GATEWAY"
                 message: "Failed to redirect request to responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances:
     post:
@@ -1019,6 +1054,7 @@ paths:
                   description: Start the process instance using latest bpmn process definition identified by bpmnProcessId.
                 variables:
                   type: object
+                  nullable: true
                 historyTimeToLive:
                   type: string
                   description: Duration for which process instance data are kept in storage after the process instance ends. If omitted the default will be picked up from engine configuration. (1d8h, 1M5d8h)
@@ -1072,6 +1108,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
     get:
       summary: Get list of running process instances
       operationId: getProcessInstances
@@ -1112,6 +1154,7 @@ paths:
             type: integer
             format: int32
             minimum: 1
+            maximum: 100
             default: 10
           description: Number of items per page
           example: 10
@@ -1221,6 +1264,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}:
     get:
@@ -1273,6 +1318,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/variables:
     patch:
@@ -1338,6 +1385,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /process-instances/{processInstanceKey}/variables/{variableName}:
     delete:
@@ -1392,6 +1445,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/child-processes:
     get:
@@ -1422,6 +1477,7 @@ paths:
             type: integer
             format: int32
             minimum: 1
+            maximum: 100
             default: 10
           description: Number of items per page
           example: 10
@@ -1500,6 +1556,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/cancel:
     post:
@@ -1548,6 +1606,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/jobs:
     get:
@@ -1636,6 +1696,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/history:
     get:
@@ -1666,9 +1728,9 @@ paths:
             type: integer
             format: int32
             minimum: 1
-            maximum: 100
+            maximum: 1000
             default: 10
-          description: Number of items per page (max 100)
+          description: Number of items per page (max 1000)
           example: 10
         - name: sortBy
           in: query
@@ -1727,6 +1789,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/incidents:
     get:
@@ -1817,6 +1881,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/event-subscriptions/messages:
     get:
@@ -1836,11 +1902,16 @@ paths:
           schema:
             type: integer
             format: int32
+            minimum: 1
+            default: 1
         - name: size
           in: query
           schema:
             type: integer
             format: int32
+            minimum: 1
+            maximum: 100
+            default: 10
         - name: state
           in: query
           schema:
@@ -1870,6 +1941,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/event-subscriptions/timers:
     get:
@@ -1889,11 +1962,16 @@ paths:
           schema:
             type: integer
             format: int32
+            minimum: 1
+            default: 1
         - name: size
           in: query
           schema:
             type: integer
             format: int32
+            minimum: 1
+            maximum: 100
+            default: 10
         - name: state
           in: query
           schema:
@@ -1923,6 +2001,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/event-subscriptions/errors:
     get:
@@ -1942,11 +2022,16 @@ paths:
           schema:
             type: integer
             format: int32
+            minimum: 1
+            default: 1
         - name: size
           in: query
           schema:
             type: integer
             format: int32
+            minimum: 1
+            maximum: 100
+            default: 10
         - name: state
           in: query
           schema:
@@ -1976,6 +2061,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /process-instances/{processInstanceKey}/statistics:
     get:
@@ -2035,6 +2122,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /jobs:
     get:
@@ -2154,6 +2243,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /jobs/{jobKey}:
     get:
@@ -2207,6 +2298,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /jobs/{jobKey}/assign:
     post:
@@ -2262,6 +2355,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /jobs/{jobKey}/complete:
     post:
@@ -2286,6 +2385,7 @@ paths:
               properties:
                 variables:
                   type: object
+                  nullable: true
             example:
               variables:
                 result: "success"
@@ -2318,6 +2418,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /jobs/{jobKey}/fail:
     post:
@@ -2345,6 +2451,7 @@ paths:
                   description: The error code against which an error catch event is matched.
                 variables:
                   type: object
+                  nullable: true
             example:
               errorCode: "123-456-789"
               variables:
@@ -2376,6 +2483,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /messages:
     post:
@@ -2398,6 +2511,7 @@ paths:
                   type: string
                 variables:
                   type: object
+                  nullable: true
             example:
               correlationKey: "011-235-813"
               messageName: "payment-received"
@@ -2445,6 +2559,12 @@ paths:
               example:
                 code: "CLUSTER_ERROR"
                 message: "Failed to redirect request to responsible node"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /incidents/{incidentKey}/resolve:
     post:
@@ -2487,6 +2607,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /modify/start-process-instance:
     post:
@@ -2510,6 +2632,7 @@ paths:
                   format: int64
                 variables:
                   type: object
+                  nullable: true
                 startingElementIds:
                   type: array
                   description: Allows for a start at chosen element id
@@ -2553,6 +2676,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /modify/process-instance:
     post:
@@ -2575,6 +2704,7 @@ paths:
                   format: int64
                 variables:
                   type: object
+                  nullable: true
                   description: Sets process instance variables.
                 elementInstancesToStart:
                   type: array
@@ -2624,6 +2754,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
+        413:
+          $ref: "#/components/responses/PayloadTooLarge"
+        415:
+          $ref: "#/components/responses/UnsupportedMediaType"
 
   /tests/{nodeId}/start-pprof-server:
     post:
@@ -2648,6 +2784,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
   /tests/{nodeId}/stop-pprof-server:
     post:
@@ -2672,8 +2810,43 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        405:
+          $ref: "#/components/responses/MethodNotAllowed"
 
 components:
+  responses:
+    MethodNotAllowed:
+      description: The HTTP method is not allowed for the requested path.
+      headers:
+        Allow:
+          description: Allowed HTTP methods for the requested path.
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            code: "METHOD_NOT_ALLOWED"
+            message: "method not allowed"
+    PayloadTooLarge:
+      description: The request body exceeds the configured size limit (httpServer.maxRequestBodyBytes, 10 MiB by default).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            code: "PAYLOAD_TOO_LARGE"
+            message: "http: request body too large"
+    UnsupportedMediaType:
+      description: The request body content type is not supported by the operation.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            code: "UNSUPPORTED_MEDIA_TYPE"
+            message: "unsupported content type"
   schemas:
     DecisionInstancePartitionPage:
       type: object

--- a/src/base/hooks/useLatestRef.ts
+++ b/src/base/hooks/useLatestRef.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Returns a ref whose `.current` always holds the most recently rendered value
+ * of `value`. Read `ref.current` to access the latest value from callbacks,
+ * intervals, and effects without forcing the consumer to re-subscribe.
+ *
+ * The ref is updated in an effect (rather than written during render) so the
+ * value satisfies the `react-hooks/refs` rule, which rejects unconditional
+ * ref writes during render as a misuse of lazy initialization.
+ *
+ * Trade-off: the ref lags by one render relative to `value`. This is
+ * acceptable for every existing call site (callbacks, effects, intervals,
+ * event handlers) because those run after render commits anyway. It is NOT
+ * appropriate when the ref value must be observed by code running in the
+ * same render that received the new `value` — for that, derive directly
+ * from `value` instead of via the ref.
+ *
+ * @example
+ *   const onClickRef = useLatestRef(onClick);
+ *   <div onClick={() => onClickRef.current?.(event)} />
+ */
+export function useLatestRef<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+}

--- a/src/base/i18n/locales/en/processInstance.json
+++ b/src/base/i18n/locales/en/processInstance.json
@@ -116,7 +116,9 @@
     "relatedJobNotFound": "No related job was found",
     "relatedJobSearchFailed": "Failed to find the related job",
     "relatedEventNotFound": "No related event subscription was found",
-    "relatedEventSearchFailed": "Failed to find the related event subscription"
+    "relatedEventSearchFailed": "Failed to find the related event subscription",
+    "historyExtremelyLarge": "History is extremely large: displaying {{loaded}} of {{total}} entries. Some data may be missing.",
+    "historyExtremelyLargeMultiple": "History is extremely large across {{instances}} process instances: displaying {{loaded}} of {{total}} entries in total. Some data may be missing."
   },
   "dialogs": {
     "completeJob": {

--- a/src/pages/ProcessInstanceDetail/ProcessInstanceDetailPage.tsx
+++ b/src/pages/ProcessInstanceDetail/ProcessInstanceDetailPage.tsx
@@ -189,12 +189,57 @@ export const ProcessInstanceDetailPage = () => {
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
     message: string;
-    severity: 'success' | 'error';
+    severity: 'success' | 'error' | 'warning';
   }>({
     open: false,
     message: '',
     severity: 'success',
   });
+
+  // Show notification helper
+  const showNotification = useCallback(
+    (message: string, severity: 'success' | 'error' | 'warning') => {
+      setSnackbar({ open: true, message, severity });
+    },
+    [],
+  );
+
+  /**
+   * History was truncated because one or more process instances reported a
+   * totalCount that exceeds the per-fetch limit. We only want to surface a
+   * single warning per fetch cycle, even when several nodes trigger it, and
+   * we suppress repeated warnings on auto-refresh by remembering the last
+   * signature we already showed.
+   */
+  const lastHistoryWarningRef = useRef<string | null>(null);
+  const handleHistoryPartial = useCallback(
+    (info: { instances: number; loadedCount: number; totalCount: number }) => {
+      // Signature covers the interesting bits so refreshing the same tree
+      // does not re-trigger the snackbar, but a real change does.
+      const signature = `${info.instances}|${info.loadedCount}|${info.totalCount}`;
+      if (lastHistoryWarningRef.current === signature) return;
+      lastHistoryWarningRef.current = signature;
+      const message =
+        info.instances > 1
+          ? t('processInstance:messages.historyExtremelyLargeMultiple', {
+              instances: info.instances,
+              loaded: info.loadedCount,
+              total: info.totalCount,
+            })
+          : t('processInstance:messages.historyExtremelyLarge', {
+              loaded: info.loadedCount,
+              total: info.totalCount,
+            });
+      showNotification(message, 'warning');
+    },
+    [showNotification, t],
+  );
+
+  // Reset the history-warning dedup signature whenever we navigate to a
+  // different process instance so the new tree is allowed to warn once too.
+  useEffect(() => {
+    lastHistoryWarningRef.current = null;
+  }, [processInstanceKey]);
 
   // Fetch data
   const {
@@ -245,7 +290,9 @@ export const ProcessInstanceDetailPage = () => {
     setErrorSubscriptionsPageSize,
     setErrorSubscriptionsState,
     totalEventSubscriptionsCount,
-  } = useInstanceData(processInstanceKey);
+  } = useInstanceData(processInstanceKey, {
+    onHistoryPartial: handleHistoryPartial,
+  });
 
   // Count of process instances shown in the Child Processes tab
   // (depth-1 + depth-2, excluding engine-internal multiInstance and subprocess wrappers).
@@ -264,11 +311,6 @@ export const ProcessInstanceDetailPage = () => {
     }
     return count;
   }, [instanceTree]);
-
-  // Show notification helper
-  const showNotification = useCallback((message: string, severity: 'success' | 'error') => {
-    setSnackbar({ open: true, message, severity });
-  }, []);
 
   const focusResolutionPending =
     focusedElementInstanceKey !== undefined && pendingFocusKey === focusedElementInstanceKey;
@@ -872,13 +914,22 @@ export const ProcessInstanceDetailPage = () => {
         </Box>
       </Paper>
 
-      {/* Success/Error Snackbar */}
+      {/* Success/Error/Warning Snackbar — Alert wrapper gives us severity coloring */}
       <Snackbar
         open={snackbar.open}
         autoHideDuration={6000}
         onClose={() => setSnackbar({ ...snackbar, open: false })}
-        message={snackbar.message}
-      />
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity={snackbar.severity}
+          variant="filled"
+          onClose={() => setSnackbar({ ...snackbar, open: false })}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };

--- a/src/pages/ProcessInstanceDetail/hooks/fetchInstanceTree.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/fetchInstanceTree.ts
@@ -38,6 +38,25 @@ export const MESSAGE_SUBSCRIPTIONS_PAGE_SIZE = 10;
 export const TIMER_SUBSCRIPTIONS_PAGE_SIZE = 10;
 export const ERROR_SUBSCRIPTIONS_PAGE_SIZE = 10;
 
+/** History page size — matches the API maximum (max 1000). */
+export const HISTORY_PAGE_SIZE = 1000;
+
+/**
+ * Maximum total number of history pages fetched: one initial request plus up
+ * to `HISTORY_MAX_PAGES - 1` follow-up requests. Total entries capped at
+ * `HISTORY_PAGE_SIZE * HISTORY_MAX_PAGES` = 10 000. Guards against runaway
+ * fetches on processes with extremely large histories.
+ */
+export const HISTORY_MAX_PAGES = 10;
+
+/**
+ * Threshold above which the user is warned that the history is extremely large
+ * and the displayed set is incomplete.  We intentionally surface this even
+ * when the displayed count equals the API total so the user knows they are
+ * looking at an unusually large dataset.
+ */
+export const HISTORY_LARGE_THRESHOLD = 10000;
+
 /**
  * Maximum number of simultaneous dataset-fetch requests in Phase 2.
  * Matches the browser's ~6 connections-per-host limit so we never queue
@@ -83,6 +102,12 @@ export async function runConcurrently<T>(
 export interface FetchInstanceTreeOptions {
   maxDepth?: number;
   childrenPageSize?: number;
+  /**
+   * Invoked once per `fetchInstanceTree` call if any node's history exceeded
+   * `HISTORY_LARGE_THRESHOLD` and could not be loaded in full. Aggregates
+   * all such nodes so the caller can show a single summary notification.
+   */
+  onHistoryPartial?: (info: { instances: number; loadedCount: number; totalCount: number }) => void;
   jobsPage?: number;
   jobsPageSize?: number;
   incidentsPage?: number;
@@ -188,6 +213,81 @@ function inferCallElementId(
 }
 
 // ---------------------------------------------------------------------------
+// History pagination
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregated result of a single node's history fetch.
+ *
+ * - `items`     — all history entries that were loaded, in API order.
+ * - `totalCount` — the value reported by the API in the first response.
+ * - `isPartial` — true when `items.length < totalCount`, i.e. the loop
+ *   stopped before reading every entry because it hit `HISTORY_MAX_PAGES`.
+ */
+interface FetchedHistory {
+  items: FlowElementHistory[];
+  totalCount: number;
+  isPartial: boolean;
+}
+
+/**
+ * Fetch every history page for one process instance using the configured
+ * page size, capping the total number of round-trips at `HISTORY_MAX_PAGES`.
+ *
+ * The first request establishes the authoritative `totalCount`. Subsequent
+ * pages are appended as long as:
+ *   - we have not reached the requested `HISTORY_MAX_PAGES` total pages,
+ *   - the previous page was non-empty (early-stop on a short final page),
+ *   - and we have not already collected every entry the API reported.
+ */
+async function fetchAllHistory(
+  key: string,
+  sortBy: GetHistorySortBy,
+  sortOrder: GetHistorySortOrder,
+): Promise<FetchedHistory> {
+  const firstPage = await getHistory(key, {
+    page: 1,
+    size: HISTORY_PAGE_SIZE,
+    sortBy,
+    sortOrder,
+  });
+
+  const items: FlowElementHistory[] = [...((firstPage.items ?? []) as FlowElementHistory[])];
+  const totalCount = firstPage.totalCount ?? items.length;
+
+  // Already complete: first page contained every entry.
+  if (items.length === 0 || items.length >= totalCount) {
+    return { items, totalCount, isPartial: false };
+  }
+
+  // Walk subsequent pages. We start at page 2 because page 1 is already loaded.
+  // With `HISTORY_MAX_PAGES` = 10 total pages this loop performs at most
+  // nine requests after page 1.
+  let knownTotal = totalCount;
+  for (let page = 2; page <= HISTORY_MAX_PAGES; page += 1) {
+    const next = await getHistory(key, {
+      page,
+      size: HISTORY_PAGE_SIZE,
+      sortBy,
+      sortOrder,
+    });
+    const nextItems = (next.items ?? []) as FlowElementHistory[];
+    if (nextItems.length === 0) break;
+    items.push(...nextItems);
+
+    // Refresh the total from a later response in case the backend updates it.
+    if (typeof next.totalCount === 'number' && next.totalCount > knownTotal) {
+      knownTotal = next.totalCount;
+    }
+
+    if (items.length >= knownTotal) break;
+    if (nextItems.length < HISTORY_PAGE_SIZE) break;
+  }
+
+  return { items, totalCount: knownTotal, isPartial: items.length < knownTotal };
+}
+
+// ---------------------------------------------------------------------------
 // Per-node dataset fetch
 // ---------------------------------------------------------------------------
 
@@ -212,7 +312,7 @@ async function fetchNodeDatasets(
     | 'messageSubscriptionsPage' | 'messageSubscriptionsPageSize' | 'messageSubscriptionsState'
     | 'timerSubscriptionsPage' | 'timerSubscriptionsPageSize' | 'timerSubscriptionsState'
     | 'errorSubscriptionsPage' | 'errorSubscriptionsPageSize' | 'errorSubscriptionsState'
-  >> & { incidentsState?: GetIncidentsState },
+  >> & { incidentsState?: GetIncidentsState; onHistoryPartial?: (info: { totalCount: number; loadedCount: number }) => void },
 ): Promise<void> {
   if (!node.isRoot && node.instance.processType === 'callActivity') {
     return;
@@ -220,13 +320,16 @@ async function fetchNodeDatasets(
 
   const key = node.instance.key;
 
+  // History is paginated sequentially (up to HISTORY_MAX_PAGES pages), so
+  // it is intentionally NOT in the parallel batch — keeping it separate also
+  // lets us surface the "extremely large" partial-history warning without
+  // entangling it with the other datasets.
   const requests: Promise<unknown>[] = [
     getProcessInstanceJobs(key, { page: opts.jobsPage, size: opts.jobsPageSize }),
     getJobs({ processInstanceKey: key, state: 'active' as JobState, page: 1, size: 1 }),
     getIncidents(key, { page: opts.incidentsPage, size: opts.incidentsPageSize, state: opts.incidentsState }),
     getIncidents(key, { state: 'unresolved' as GetIncidentsState, page: 1, size: 1 }),
     getDecisionInstances({ processInstanceKey: key, page: opts.decisionsPage, size: opts.decisionsPageSize }),
-    getHistory(key, { page: 1, size: -1, sortBy: opts.historySortBy, sortOrder: opts.historySortOrder }),
     getProcessInstanceMessageSubscriptions(key, { state: opts.messageSubscriptionsState ?? "active", page: opts.messageSubscriptionsPage, size: opts.messageSubscriptionsPageSize }),
     getProcessInstanceTimerSubscriptions(key, { state: opts.timerSubscriptionsState ?? "active", page: opts.timerSubscriptionsPage, size: opts.timerSubscriptionsPageSize }),
     getProcessInstanceErrorSubscriptions(key, { state: opts.errorSubscriptionsState ?? "active", page: opts.errorSubscriptionsPage, size: opts.errorSubscriptionsPageSize }),
@@ -237,7 +340,7 @@ async function fetchNodeDatasets(
     getProcessInstanceErrorSubscriptions(key, { state: 'active', page: 1, size: 100 }),
   ];
 
-  const [jobsResult, activeJobsResult, incidentsResult, unresolvedResult, decisionsResult, historyResult, messageSubsResult, timerSubsResult, errorSubsResult, allMsgSubsResult, allTimerSubsResult, allErrSubsResult] = await Promise.allSettled(requests);
+  const [jobsResult, activeJobsResult, incidentsResult, unresolvedResult, decisionsResult, messageSubsResult, timerSubsResult, errorSubsResult, allMsgSubsResult, allTimerSubsResult, allErrSubsResult] = await Promise.allSettled(requests);
 
   if (jobsResult.status === 'fulfilled' && jobsResult.value) {
     const v = jobsResult.value as Awaited<ReturnType<typeof getProcessInstanceJobs>>;
@@ -265,11 +368,6 @@ async function fetchNodeDatasets(
     const v = decisionsResult.value as Awaited<ReturnType<typeof getDecisionInstances>>;
     node.decisions = (v.partitions ?? []).flatMap((p) => p.items ?? []) as DecisionInstanceSummary[];
     node.decisionsTotalCount = v.totalCount ?? 0;
-  }
-
-  if (historyResult.status === 'fulfilled' && historyResult.value) {
-    const v = historyResult.value as Awaited<ReturnType<typeof getHistory>>;
-    node.history = (v.items ?? []) as FlowElementHistory[];
   }
 
   if (messageSubsResult.status === 'fulfilled' && messageSubsResult.value) {
@@ -303,6 +401,22 @@ async function fetchNodeDatasets(
   if (allErrSubsResult.status === 'fulfilled' && allErrSubsResult.value) {
     const v = allErrSubsResult.value as Awaited<ReturnType<typeof getProcessInstanceErrorSubscriptions>>;
     node.allActiveErrorSubscriptions = (v.items ?? []) as ErrorSubscription[];
+  }
+
+  // History: paged sequentially so we can stop early on a short final page.
+  // Failures are swallowed (logged elsewhere) so one bad history fetch cannot
+  // abort the rest of the tree load.
+  try {
+    const history = await fetchAllHistory(key, opts.historySortBy, opts.historySortOrder);
+    node.history = history.items;
+    // Only surface the "extremely large" warning when the dataset is genuinely
+    // incomplete AND the reported total crosses the threshold.  We still
+    // attach `totalCount` for callers that want it later.
+    if (history.isPartial && history.totalCount > HISTORY_LARGE_THRESHOLD) {
+      opts.onHistoryPartial?.({ totalCount: history.totalCount, loadedCount: history.items.length });
+    }
+  } catch (err) {
+    console.error(`Failed to fetch history for ${key}:`, err);
   }
 
   // Variables are embedded in instance.variables — slice the current page
@@ -340,7 +454,7 @@ export async function fetchInstanceTree(
 ): Promise<ProcessInstanceNode> {
   const maxDepth = opts.maxDepth ?? MAX_TREE_DEPTH;
   const childrenPageSize = opts.childrenPageSize ?? CHILDREN_PAGE_SIZE;
-  const datasetOpts = {
+  const datasetOpts: Parameters<typeof fetchNodeDatasets>[1] = {
     jobsPage: opts.jobsPage ?? 1,
     jobsPageSize: opts.jobsPageSize ?? JOBS_PAGE_SIZE,
     incidentsPage: opts.incidentsPage ?? 1,
@@ -363,6 +477,12 @@ export async function fetchInstanceTree(
     errorSubscriptionsState: opts.errorSubscriptionsState ?? 'active',
   };
   const terminalCache = opts.terminalNodeCache ?? new Map<string, ProcessInstanceNode>();
+
+  // Per-call accumulator for nodes whose history was truncated. Filled by the
+  // `onHistoryPartial` callback below and reported once after Phase 2 completes
+  // so the caller can show a single summary notification instead of one per node.
+  const partialHistories: Array<{ totalCount: number; loadedCount: number }> = [];
+  datasetOpts.onHistoryPartial = (info) => partialHistories.push(info);
 
   // ── Phase 1: build tree shape ────────────────────────────────────────────
 
@@ -466,6 +586,19 @@ export async function fetchInstanceTree(
     // (N_deep_nodes × 5) API calls on every refresh.
     return fetchNodeDatasets(node, datasetOpts);
   });
+
+  // Surface a single aggregated "extremely large history" event after all
+  // dataset fetches have settled, so the user sees one summary instead of N
+  // snackbars (one per truncated node, especially during 5s auto-refresh).
+  if (partialHistories.length > 0) {
+    const loadedCount = partialHistories.reduce((sum, p) => sum + p.loadedCount, 0);
+    const totalCount = partialHistories.reduce((sum, p) => sum + p.totalCount, 0);
+    opts.onHistoryPartial?.({
+      instances: partialHistories.length,
+      loadedCount,
+      totalCount,
+    });
+  }
 
   // ── Phase 3: derive callElementId for each non-root node ─────────────────
   // Now that history is populated, infer which element in the parent called
@@ -617,17 +750,40 @@ export function refetchNodeVariables(
 
 /**
  * Re-fetch history for a specific node with new sort parameters (mutates the node).
+ *
+ * Uses the same paginated fetch as the initial load so a sort change on a node
+ * with a very large history still shows all available entries (up to
+ * `HISTORY_MAX_PAGES` pages).  If the dataset is larger than that and is
+ * truncated, the partial-history warning callback supplied via
+ * `options.onHistoryPartial` fires once with the aggregated info.
+ *
+ * Pass `options.isStale` to skip applying results when the request has been
+ * superseded by a newer one. The check is performed after the network
+ * response arrives but BEFORE mutating `node.history`, so a slow older
+ * request that resolves last cannot clobber the fresh data already written
+ * by a newer request.
+ *
  * Returns the updated node for convenience.
  */
 export async function refetchNodeHistory(
   node: ProcessInstanceNode,
   sortBy: GetHistorySortBy,
   sortOrder: GetHistorySortOrder,
+  options: {
+    onHistoryPartial?: (info: { totalCount: number; loadedCount: number }) => void;
+    isStale?: () => boolean;
+  } = {},
 ): Promise<ProcessInstanceNode> {
   if (!node.isRoot && node.instance.processType === 'callActivity') return node;
   try {
-    const data = await getHistory(node.instance.key, { page: 1, size: 100, sortBy, sortOrder });
-    node.history = (data.items ?? []) as FlowElementHistory[];
+    const history = await fetchAllHistory(node.instance.key, sortBy, sortOrder);
+    // Bail before mutating the shared tree if this request belongs to a
+    // sort generation the caller has already moved past.
+    if (options.isStale?.()) return node;
+    node.history = history.items;
+    if (history.isPartial && history.totalCount > HISTORY_LARGE_THRESHOLD) {
+      options.onHistoryPartial?.({ totalCount: history.totalCount, loadedCount: history.items.length });
+    }
   } catch (err) {
     console.error(`Failed to refetch history for ${node.instance.key}:`, err);
   }

--- a/src/pages/ProcessInstanceDetail/hooks/index.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/index.ts
@@ -1,5 +1,5 @@
 export { useInstanceData, TERMINAL_STATES, AUTO_REFRESH_INTERVAL } from './useInstanceData';
-export type { UseInstanceDataResult } from './useInstanceData';
+export type { UseInstanceDataResult, UseInstanceDataOptions } from './useInstanceData';
 export { findFocusedJobPage } from './findFocusedJobPage';
 export { findFocusedEventPage } from './findFocusedEventPage';
 export type { FocusedEventType, FocusedEventPage } from './findFocusedEventPage';
@@ -11,4 +11,7 @@ export {
   INCIDENTS_PAGE_SIZE,
   DECISIONS_PAGE_SIZE,
   VARIABLES_PAGE_SIZE,
+  HISTORY_PAGE_SIZE,
+  HISTORY_MAX_PAGES,
+  HISTORY_LARGE_THRESHOLD,
 } from './fetchInstanceTree';

--- a/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useLatestRef } from '@base/hooks/useLatestRef';
 import {
   getProcessDefinition,
   getProcessInstance,
@@ -219,10 +220,8 @@ export const useInstanceData = (
   // History sort state
   const [historySortBy, setHistorySortBy] = useState<GetHistorySortBy>('createdAt');
   const [historySortOrder, setHistorySortOrder] = useState<GetHistorySortOrder>('asc');
-  const historySortByRef = useRef<GetHistorySortBy>('createdAt');
-  const historySortOrderRef = useRef<GetHistorySortOrder>('asc');
-  historySortByRef.current = historySortBy;
-  historySortOrderRef.current = historySortOrder;
+  const historySortByRef = useLatestRef(historySortBy);
+  const historySortOrderRef = useLatestRef(historySortOrder);
   // Generation counter for the history-sort effect. Bumped in the effect
   // cleanup so an in-flight (slower) sort request whose response arrives
   // after the user has already triggered a newer sort change cannot
@@ -232,49 +231,29 @@ export const useInstanceData = (
 
   // Refs so fetchAll (auto-refresh) always reads the current pagination values
   // without stale closure captures.
-  const jobsPageRef = useRef(0);
-  const jobsPageSizeRef = useRef(JOBS_PAGE_SIZE);
-  const incidentsPageRef = useRef(0);
-  const incidentsPageSizeRef = useRef(INCIDENTS_PAGE_SIZE);
-  const incidentsStateRef = useRef<GetIncidentsState | 'all'>('all');
-  const decisionsPageRef = useRef(0);
-  const decisionsPageSizeRef = useRef(DECISIONS_PAGE_SIZE);
-  const variablesPageRef = useRef(0);
-  const variablesPageSizeRef = useRef(VARIABLES_PAGE_SIZE);
+  const jobsPageRef = useLatestRef(jobsPage);
+  const jobsPageSizeRef = useLatestRef(jobsPageSize);
+  const incidentsPageRef = useLatestRef(incidentsPage);
+  const incidentsPageSizeRef = useLatestRef(incidentsPageSize);
+  const incidentsStateRef = useLatestRef(incidentsState);
+  const decisionsPageRef = useLatestRef(decisionsPage);
+  const decisionsPageSizeRef = useLatestRef(decisionsPageSize);
+  const variablesPageRef = useLatestRef(variablesPage);
+  const variablesPageSizeRef = useLatestRef(variablesPageSize);
 
   // Subscription pagination refs
-  const messageSubscriptionsPageRef = useRef(0);
-  const messageSubscriptionsPageSizeRef = useRef(MESSAGE_SUBSCRIPTIONS_PAGE_SIZE);
-  const messageSubscriptionsStateRef = useRef<EventSubscriptionState>('active');
-  const timerSubscriptionsPageRef = useRef(0);
-  const timerSubscriptionsPageSizeRef = useRef(TIMER_SUBSCRIPTIONS_PAGE_SIZE);
-  const timerSubscriptionsStateRef = useRef<EventSubscriptionState>('active');
-  const errorSubscriptionsPageRef = useRef(0);
-  const errorSubscriptionsPageSizeRef = useRef(ERROR_SUBSCRIPTIONS_PAGE_SIZE);
-  const errorSubscriptionsStateRef = useRef<EventSubscriptionState>('active');
-  jobsPageRef.current = jobsPage;
-  jobsPageSizeRef.current = jobsPageSize;
-  incidentsPageRef.current = incidentsPage;
-  incidentsPageSizeRef.current = incidentsPageSize;
-  incidentsStateRef.current = incidentsState;
-  decisionsPageRef.current = decisionsPage;
-  decisionsPageSizeRef.current = decisionsPageSize;
-  variablesPageRef.current = variablesPage;
-  variablesPageSizeRef.current = variablesPageSize;
-
-  messageSubscriptionsPageRef.current = messageSubscriptionsPage;
-  messageSubscriptionsPageSizeRef.current = messageSubscriptionsPageSize;
-  messageSubscriptionsStateRef.current = messageSubscriptionsState;
-  timerSubscriptionsPageRef.current = timerSubscriptionsPage;
-  timerSubscriptionsPageSizeRef.current = timerSubscriptionsPageSize;
-  timerSubscriptionsStateRef.current = timerSubscriptionsState;
-  errorSubscriptionsPageRef.current = errorSubscriptionsPage;
-  errorSubscriptionsPageSizeRef.current = errorSubscriptionsPageSize;
-  errorSubscriptionsStateRef.current = errorSubscriptionsState;
+  const messageSubscriptionsPageRef = useLatestRef(messageSubscriptionsPage);
+  const messageSubscriptionsPageSizeRef = useLatestRef(messageSubscriptionsPageSize);
+  const messageSubscriptionsStateRef = useLatestRef(messageSubscriptionsState);
+  const timerSubscriptionsPageRef = useLatestRef(timerSubscriptionsPage);
+  const timerSubscriptionsPageSizeRef = useLatestRef(timerSubscriptionsPageSize);
+  const timerSubscriptionsStateRef = useLatestRef(timerSubscriptionsState);
+  const errorSubscriptionsPageRef = useLatestRef(errorSubscriptionsPage);
+  const errorSubscriptionsPageSizeRef = useLatestRef(errorSubscriptionsPageSize);
+  const errorSubscriptionsStateRef = useLatestRef(errorSubscriptionsState);
 
   // Ref to always access the latest tree without stale closures.
-  const instanceTreeRef = useRef(instanceTree);
-  instanceTreeRef.current = instanceTree;
+  const instanceTreeRef = useLatestRef(instanceTree);
 
   // Track the last successfully fetched process definition key so we never
   // re-fetch the definition (it never changes for the same instance).
@@ -291,8 +270,7 @@ export const useInstanceData = (
   // Latest caller-provided history callback. Stored in a ref so refreshes
   // always read the freshest closure without forcing the whole hook to
   // re-subscribe to `options`.
-  const onHistoryPartialRef = useRef(options?.onHistoryPartial);
-  onHistoryPartialRef.current = options?.onHistoryPartial;
+  const onHistoryPartialRef = useLatestRef(options?.onHistoryPartial);
 
   // ── Subprocess element statistics ─────────────────────────────────────────
   const fetchSubprocessStats = useCallback(
@@ -392,6 +370,10 @@ export const useInstanceData = (
     } finally {
       isFetchingRef.current = false;
     }
+    // The pagination/history/tree/onHistoryPartial refs read inside this callback are
+    // all stable (created via useLatestRef). Tracking each one in the deps array would
+    // be runtime-identical but visually noisy; suppress the rule instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [processInstanceKey, fetchSubprocessStats]);
 
   // ── Initial data fetch ────────────────────────────────────────────────────
@@ -456,14 +438,17 @@ export const useInstanceData = (
     };
 
     void fetchData();
+    // `fetchAll` reads all stable refs (created via useLatestRef); they are captured
+    // transitively through `fetchAll`'s identity. Adding each one here would be
+    // runtime-identical but visually noisy; suppress the rule instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [processInstanceKey, fetchAll]);
 
   // ── Periodic auto-refresh for active instances ────────────────────────────
   const isActiveInstance =
     instanceTree?.instance && !TERMINAL_STATES.includes(instanceTree.instance.state);
 
-  const fetchAllRef = useRef(fetchAll);
-  fetchAllRef.current = fetchAll;
+  const fetchAllRef = useLatestRef(fetchAll);
 
   useEffect(() => {
     if (!processInstanceKey || loading || !isActiveInstance) return;
@@ -474,7 +459,9 @@ export const useInstanceData = (
       void fetchAllRef.current();
     }, AUTO_REFRESH_INTERVAL);
     return () => clearInterval(intervalId);
-  }, [processInstanceKey, loading, isActiveInstance]);
+    // fetchAllRef is a stable ref (created via useLatestRef); omitting it
+    // here would be harmless at runtime but trips the exhaustive-deps rule.
+  }, [processInstanceKey, loading, isActiveInstance, fetchAllRef]);
 
   // ── Root element statistics via React Query (auto-poll) ───────────────────
   // Enabled as soon as the key is known — no need to wait for the definition.
@@ -533,7 +520,8 @@ export const useInstanceData = (
     const nodes = collectAllNodes(tree);
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeJobs(node, jobsPage + 1, jobsPageSize))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)));
-  }, [jobsPage, jobsPageSize]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [jobsPage, jobsPageSize, instanceTreeRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -542,7 +530,8 @@ export const useInstanceData = (
     const nodes = collectAllNodes(tree);
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeIncidents(node, incidentsPage + 1, incidentsPageSize, incidentsState === 'all' ? undefined : incidentsState))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)));
-  }, [incidentsPage, incidentsPageSize, incidentsState]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [incidentsPage, incidentsPageSize, incidentsState, instanceTreeRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -551,7 +540,8 @@ export const useInstanceData = (
     const nodes = collectAllNodes(tree);
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeDecisions(node, decisionsPage + 1, decisionsPageSize))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)));
-  }, [decisionsPage, decisionsPageSize]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [decisionsPage, decisionsPageSize, instanceTreeRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -560,7 +550,8 @@ export const useInstanceData = (
     const nodes = collectAllNodes(tree);
     nodes.forEach((node) => doRefetchNodeVariables(node, variablesPage + 1, variablesPageSize));
     setInstanceTree((prev) => (prev ? { ...prev } : prev));
-  }, [variablesPage, variablesPageSize]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [variablesPage, variablesPageSize, instanceTreeRef]);
 
   const setHistorySort = useCallback((sortBy: GetHistorySortBy, sortOrder: GetHistorySortOrder) => {
     setHistorySortBy(sortBy);
@@ -619,7 +610,8 @@ export const useInstanceData = (
         historySortGenerationRef.current += 1;
       }
     };
-  }, [historySortBy, historySortOrder]);
+    // instanceTreeRef and onHistoryPartialRef are stable refs (created via useLatestRef).
+  }, [historySortBy, historySortOrder, instanceTreeRef, onHistoryPartialRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -629,7 +621,8 @@ export const useInstanceData = (
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeMessageSubscriptions(node, messageSubscriptionsPage + 1, messageSubscriptionsPageSize, messageSubscriptionsState))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)))
       .catch((err: unknown) => console.error('Failed to paginate message subscriptions:', err));
-  }, [messageSubscriptionsPage, messageSubscriptionsPageSize, messageSubscriptionsState]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [messageSubscriptionsPage, messageSubscriptionsPageSize, messageSubscriptionsState, instanceTreeRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -639,7 +632,8 @@ export const useInstanceData = (
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeTimerSubscriptions(node, timerSubscriptionsPage + 1, timerSubscriptionsPageSize, timerSubscriptionsState))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)))
       .catch((err: unknown) => console.error('Failed to paginate timer subscriptions:', err));
-  }, [timerSubscriptionsPage, timerSubscriptionsPageSize, timerSubscriptionsState]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [timerSubscriptionsPage, timerSubscriptionsPageSize, timerSubscriptionsState, instanceTreeRef]);
 
   useEffect(() => {
     if (!initialLoadDoneRef.current) return;
@@ -649,7 +643,8 @@ export const useInstanceData = (
     void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeErrorSubscriptions(node, errorSubscriptionsPage + 1, errorSubscriptionsPageSize, errorSubscriptionsState))
       .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)))
       .catch((err: unknown) => console.error('Failed to paginate error subscriptions:', err));
-  }, [errorSubscriptionsPage, errorSubscriptionsPageSize, errorSubscriptionsState]);
+    // instanceTreeRef is a stable ref (created via useLatestRef).
+  }, [errorSubscriptionsPage, errorSubscriptionsPageSize, errorSubscriptionsState, instanceTreeRef]);
 
   const totalEventSubscriptionsCount = useMemo(() => {
     if (!instanceTree) return 0;

--- a/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
+++ b/src/pages/ProcessInstanceDetail/hooks/useInstanceData.ts
@@ -45,6 +45,20 @@ export const TERMINAL_STATES = ['completed', 'terminated'];
 export const AUTO_REFRESH_INTERVAL = 5000;
 
 // ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface UseInstanceDataOptions {
+  /**
+   * Fired when one or more process instances in the tree report a total
+   * history count greater than the API/page limit so the displayed set is
+   * incomplete. The hook aggregates per-fetch results into a single call
+   * (one snackbar per fetch cycle, not one per truncated node).
+   */
+  onHistoryPartial?: (info: { instances: number; loadedCount: number; totalCount: number }) => void;
+}
+
+// ---------------------------------------------------------------------------
 // Result interface
 // ---------------------------------------------------------------------------
 
@@ -170,6 +184,7 @@ function projectCalledProcessIncidents(
 
 export const useInstanceData = (
   processInstanceKey: string | undefined,
+  options?: UseInstanceDataOptions,
 ): UseInstanceDataResult => {
   const [instanceTree, setInstanceTree] = useState<ProcessInstanceNode | null>(null);
   const [processDefinition, setProcessDefinition] = useState<ProcessDefinition | null>(null);
@@ -208,6 +223,12 @@ export const useInstanceData = (
   const historySortOrderRef = useRef<GetHistorySortOrder>('asc');
   historySortByRef.current = historySortBy;
   historySortOrderRef.current = historySortOrder;
+  // Generation counter for the history-sort effect. Bumped in the effect
+  // cleanup so an in-flight (slower) sort request whose response arrives
+  // after the user has already triggered a newer sort change cannot
+  // overwrite `node.history` on the shared tree. Without this guard, an
+  // older request that finishes last silently corrupts the rendered order.
+  const historySortGenerationRef = useRef(0);
 
   // Refs so fetchAll (auto-refresh) always reads the current pagination values
   // without stale closure captures.
@@ -266,6 +287,12 @@ export const useInstanceData = (
   // takes longer than AUTO_REFRESH_INTERVAL the next tick starts a second rebuild
   // before the first finishes, doubling the load and causing state flicker.
   const isFetchingRef = useRef(false);
+
+  // Latest caller-provided history callback. Stored in a ref so refreshes
+  // always read the freshest closure without forcing the whole hook to
+  // re-subscribe to `options`.
+  const onHistoryPartialRef = useRef(options?.onHistoryPartial);
+  onHistoryPartialRef.current = options?.onHistoryPartial;
 
   // ── Subprocess element statistics ─────────────────────────────────────────
   const fetchSubprocessStats = useCallback(
@@ -335,6 +362,7 @@ export const useInstanceData = (
         maxDepth: MAX_TREE_DEPTH,
         preloadedRoot: rootInstance,
         terminalNodeCache,
+        onHistoryPartial: (info) => onHistoryPartialRef.current?.(info),
         jobsPage: jobsPageRef.current + 1,
         jobsPageSize: jobsPageSizeRef.current,
         incidentsPage: incidentsPageRef.current + 1,
@@ -544,8 +572,53 @@ export const useInstanceData = (
     const tree = instanceTreeRef.current;
     if (!tree) return;
     const nodes = collectAllNodes(tree);
-    void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) => doRefetchNodeHistory(node, historySortBy, historySortOrder))
-      .then(() => setInstanceTree((prev) => (prev ? { ...prev } : prev)));
+    // Capture the current generation. Cleanup runs before the next effect
+    // and bumps the ref, so any in-flight request whose response arrives
+    // later can compare against `historySortGenerationRef.current` and
+    // bail out — both before mutating `node.history` (handled inside
+    // `refetchNodeHistory` via `isStale`) and before triggering a re-render
+    // or snackbar here. This prevents a slow older sort request that
+    // resolves last from clobbering fresh data already written by a
+    // newer sort request.
+    const myGeneration = ++historySortGenerationRef.current;
+    const isStale = () => historySortGenerationRef.current !== myGeneration;
+    // Per-sort-change aggregator so we still emit a single notification even
+    // when several nodes in the tree trigger partial-history warnings.
+    const partialHistories: Array<{ totalCount: number; loadedCount: number }> = [];
+    void runConcurrently(nodes, CONCURRENT_FETCH_LIMIT, (node) =>
+      doRefetchNodeHistory(node, historySortBy, historySortOrder, {
+        // Discard partial-history signals from stale sort generations.
+        onHistoryPartial: (info) => {
+          if (isStale()) return;
+          partialHistories.push(info);
+        },
+        isStale,
+      }),
+    )
+      .then(() => {
+        // If the user has since changed the sort, this response is stale —
+        // skip the re-render and snackbar. (The mutation guard inside
+        // `refetchNodeHistory` already prevented `node.history` from being
+        // overwritten by stale data.)
+        if (isStale()) return;
+        if (partialHistories.length > 0) {
+          onHistoryPartialRef.current?.({
+            instances: partialHistories.length,
+            loadedCount: partialHistories.reduce((sum, p) => sum + p.loadedCount, 0),
+            totalCount: partialHistories.reduce((sum, p) => sum + p.totalCount, 0),
+          });
+        }
+        setInstanceTree((prev) => (prev ? { ...prev } : prev));
+      });
+    // Invalidate this generation on the next render. Order matters: the
+    // bump MUST happen after we've captured `myGeneration` above (so this
+    // effect's own body isn't self-invalidated) and BEFORE the next
+    // effect's body runs (so the new effect sees a fresh generation).
+    return () => {
+      if (historySortGenerationRef.current === myGeneration) {
+        historySortGenerationRef.current += 1;
+      }
+    };
   }, [historySortBy, historySortOrder]);
 
   useEffect(() => {

--- a/src/pages/ProcessInstanceDetail/types/tree.ts
+++ b/src/pages/ProcessInstanceDetail/types/tree.ts
@@ -28,8 +28,12 @@ export type TreeDatasetPagination = Record<string, NodePagination>;
  * The root node sits at depth=0.  Each node carries its own paginated
  * dataset snapshots; child nodes are nested under `children`.
  *
- * History is fetched in full (size: -1) and is therefore client-paged only —
- * there is no server-side pagination state for it.
+ * History is fetched across up to `HISTORY_MAX_PAGES` server pages of
+ * `HISTORY_PAGE_SIZE` items each (see `fetchInstanceTree`) so a normal-sized
+ * instance loads in a single round-trip.  When the server reports more
+ * entries than fit in those pages, the displayed `history` array is
+ * truncated and the user is warned.  There is no server-side pagination
+ * state for history — the tab itself is client-paged.
  */
 export interface ProcessInstanceNode {
   /** Full process instance object — includes `variables` and `activeElementInstances` */
@@ -79,7 +83,7 @@ export interface ProcessInstanceNode {
   variableEntries: Array<{ name: string; value: unknown }>;
   variablesTotalCount: number;
 
-  // --- History (client-paged only, fetched in full) ---
+  // --- History (client-paged only; server-paginated up to HISTORY_MAX_PAGES pages) ---
   history: FlowElementHistory[];
 
   // --- Message subscriptions (server-paginated) ---
@@ -101,14 +105,14 @@ export interface ProcessInstanceNode {
   allActiveMessageSubscriptions: MessageSubscription[];
 
   /**
-   * All active timer subscriptions for this node, fetched in full (size: -1,
-   * state: 'active'). Used for diagram badges.
+   * All active timer subscriptions for this node, fetched with a large page
+   * size (size: 100, state: 'active'). Used for diagram badges.
    */
   allActiveTimerSubscriptions: TimerSubscription[];
 
   /**
-   * All active error subscriptions for this node, fetched in full (size: -1,
-   * state: 'active'). Used for diagram badges.
+   * All active error subscriptions for this node, fetched with a large page
+   * size (size: 100, state: 'active'). Used for diagram badges.
    */
   allActiveErrorSubscriptions: ErrorSubscription[];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process-instance history now loads in pages, supporting large histories while limiting excessive requests.
  * Added clear warnings when history is only partially loaded, including loaded and total entry counts.
  * Warning notifications now appear alongside success and error messages with improved visual styling.

* **API Improvements**
  * Updated API documentation to version 1.6.0 with clearer error responses and request limits.
  * Added pagination limits for subscriptions and expanded process-instance history capacity.
  * Upload requests now support XML and the configured request-size limit.
  * Several API variables can now be explicitly set to null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->