### PR TITLE
#689 - partition pages REST API responses are inconsistent

### DIFF
--- a/e2e/core/partitioned-pagination.spec.ts
+++ b/e2e/core/partitioned-pagination.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+const PROCESS_DEFINITION_KEY = '3000000000000000033';
+
+test('partitioned pagination uses the largest partition total', async ({ page }) => {
+  const requestedPages: number[] = [];
+
+  await page.goto(`/process-definitions/${PROCESS_DEFINITION_KEY}`);
+  await expect(page.getByText('Process Instances')).toBeVisible();
+
+  await page.evaluate(async () => {
+    // The Vite-served module is available in the browser, not to Playwright's Node type resolver.
+    // @ts-expect-error browser-only module URL
+    const { worker } = await import('/src/mocks/browser.ts');
+    worker.stop();
+  });
+
+  await page.route('**/v1/process-instances**', async (route) => {
+    const requestedPage = Number(new URL(route.request().url()).searchParams.get('page') ?? '1');
+    requestedPages.push(requestedPage);
+
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(createPartitionedResponse(requestedPage)),
+    });
+  });
+
+  const stateFilter = page.locator('.MuiFormControl-root').filter({ hasText: 'State' }).first();
+  await stateFilter.click();
+  await page.getByRole('option', { name: 'Active' }).click();
+
+  await expect.poll(() => requestedPages).toContain(1);
+
+  await expect(page.getByRole('button', { name: 'Go to page 3' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Go to page 4' })).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Go to page 3' }).click();
+  await expect.poll(() => requestedPages).toContain(3);
+});
+
+function createPartitionedResponse(page: number) {
+  const partitionTotals = [12, 4, 9];
+
+  return {
+    partitions: partitionTotals.map((totalCount, index) => ({
+      partition: index + 1,
+      totalCount,
+      items: page === 1 || totalCount > (page - 1) * 5
+        ? [{
+            key: `310000000000000000${index}`,
+            processDefinitionKey: PROCESS_DEFINITION_KEY,
+            bpmnProcessId: 'showcase-process',
+            createdAt: '2026-08-23T12:00:00Z',
+            state: 'active',
+            processType: 'default',
+            variables: {},
+            incidentCount: 0,
+          }]
+        : [],
+    })),
+    page,
+    size: 5,
+    count: partitionTotals.filter((totalCount) => page === 1 || totalCount > (page - 1) * 5).length,
+    totalCount: partitionTotals.reduce((sum, totalCount) => sum + totalCount, 0),
+  };
+}
+

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -446,7 +446,7 @@ paths:
               example:
                 partitions:
                   - partition: 1
-                    count: 156
+                    totalCount: 156
                     items:
                       - key: 4503599627370600
                         dmnResourceDefinitionKey: 4503599627370495
@@ -457,7 +457,7 @@ paths:
                         inputCount: 3
                         outputCount: 2
                   - partition: 2
-                    count: 98
+                    totalCount: 98
                     items:
                       - key: 9007199254740995
                         dmnResourceDefinitionKey: 4503599627370495
@@ -973,31 +973,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProcessDefinitionStatisticsPage"
               example:
-                items:
-                  - key: 4503599627370498
-                    version: 3
-                    bpmnProcessId: "loan-application"
-                    name: "Loan Application Process"
-                    bpmnResourceName: "loan-application.bpmn"
-                    instanceCounts:
-                      total: 1250
-                      active: 45
-                      completed: 1180
-                      terminated: 20
-                      failed: 5
-                      withIncident: 0
-                  - key: 4503599627370510
-                    version: 1
-                    bpmnProcessId: "order-fulfillment"
-                    name: "Order Fulfillment"
-                    bpmnResourceName: "order-fulfillment.bpmn"
-                    instanceCounts:
-                      total: 890
-                      active: 120
-                      completed: 750
-                      terminated: 15
-                      failed: 5
-                      withIncident: 2
+                partitions:
+                  - partition: 1
+                    totalCount: 2
+                    items:
+                      - key: 4503599627370498
+                        version: 3
+                        bpmnProcessId: "loan-application"
+                        name: "Loan Application Process"
+                        bpmnResourceName: "loan-application.bpmn"
+                        instanceCounts:
+                          total: 1250
+                          active: 45
+                          completed: 1180
+                          terminated: 20
+                          failed: 5
+                          withIncident: 0
+                      - key: 4503599627370510
+                        version: 1
+                        bpmnProcessId: "order-fulfillment"
+                        name: "Order Fulfillment"
+                        bpmnResourceName: "order-fulfillment.bpmn"
+                        instanceCounts:
+                          total: 890
+                          active: 120
+                          completed: 750
+                          terminated: 15
+                          failed: 5
+                          withIncident: 2
                 page: 1
                 size: 10
                 count: 2
@@ -1207,7 +1210,7 @@ paths:
               example:
                 partitions:
                   - partition: 1
-                    count: 24
+                    totalCount: 24
                     items:
                       - key: 4503599627370501
                         processDefinitionKey: 4503599627370498
@@ -1230,7 +1233,7 @@ paths:
                           amount: 5000
                           applicationDate: "2025-08-22"
                   - partition: 2
-                    count: 18
+                    totalCount: 18
                     items:
                       - key: 9007199254740992
                         processDefinitionKey: 4503599627370498
@@ -1504,6 +1507,7 @@ paths:
               example:
                 partitions:
                   - partition: 1
+                    totalCount: 2
                     items:
                       - key: 4503599627370501
                         processDefinitionKey: 4503599627370498
@@ -1524,6 +1528,7 @@ paths:
                           amount: 5000
                           applicationDate: "2025-08-22"
                   - partition: 2
+                    totalCount: 1
                     items:
                       - key: 9007199254740992
                         processDefinitionKey: 4503599627370498
@@ -2198,6 +2203,7 @@ paths:
               example:
                 partitions:
                   - partition: 1
+                    totalCount: 1
                     items:
                       - key: 4503599627370540
                         elementId: "Task_ReviewApplication"
@@ -2210,6 +2216,7 @@ paths:
                         inputVariables:
                           formKey: "loan-review-form"
                   - partition: 2
+                    totalCount: 1
                     items:
                       - key: 9007199254740995
                         elementId: "Task_SendNotification"
@@ -2865,12 +2872,13 @@ components:
       required:
         - partition
         - items
+        - totalCount
       properties:
         partition:
           type: integer
-        count:
+        totalCount:
           type: integer
-          description: Total decision instances in this partition
+          description: Total number of items available in this partition
         items:
           type: array
           items:
@@ -3033,9 +3041,13 @@ components:
       required:
         - partition
         - items
+        - totalCount
       properties:
         partition:
           type: integer
+        totalCount:
+          type: integer
+          description: Total number of items available in this partition
         items:
           type: array
           items:
@@ -3283,9 +3295,13 @@ components:
       required:
         - partition
         - items
+        - totalCount
       properties:
         partition:
           type: integer
+        totalCount:
+          type: integer
+          description: Total number of items available in this partition
         items:
           type: array
           items:
@@ -3601,9 +3617,13 @@ components:
       required:
         - partition
         - items
+        - totalCount
       properties:
         partition:
           type: integer
+        totalCount:
+          type: integer
+          description: Total number of items available in this partition
         items:
           type: array
           items:

--- a/src/components/DecisionInstancesTable/DecisionInstancesTable.tsx
+++ b/src/components/DecisionInstancesTable/DecisionInstancesTable.tsx
@@ -166,7 +166,7 @@ export const DecisionInstancesTable = ({
       return {
         partitions: data.partitions?.map((p) => ({
           partition: p.partition,
-          count: p.count,
+          totalCount: p.totalCount,
           items: p.items || [],
         })) || [],
         page: data.page,

--- a/src/components/IncidentsTable/IncidentsTable.tsx
+++ b/src/components/IncidentsTable/IncidentsTable.tsx
@@ -67,7 +67,7 @@ export const IncidentsTable = ({
 
       // Wrap simple paginated response in partitioned format
       return {
-        partitions: [{ partition: 1, items: responseData.items as Incident[] }],
+        partitions: [{ partition: 1, items: responseData.items as Incident[], totalCount: responseData.totalCount }],
         page: responseData.page,
         size: responseData.size,
         count: responseData.count,

--- a/src/components/PartitionedTable/PartitionedTable.tsx
+++ b/src/components/PartitionedTable/PartitionedTable.tsx
@@ -179,7 +179,7 @@ export const PartitionedTable = <T extends object>({
                   <Fragment key={partition.partition}>
                     <PartitionHeader
                       partition={partition.partition}
-                      count={partition.count}
+                      count={partition.totalCount}
                       page={page}
                       pageSize={pageSize}
                       colSpan={columns.length}

--- a/src/components/PartitionedTable/hooks/usePartitionedData.ts
+++ b/src/components/PartitionedTable/hooks/usePartitionedData.ts
@@ -78,7 +78,6 @@ export function usePartitionedData<T extends object>({
   const prevFiltersRef = useRef<FilterValues | undefined>(filters);
   // Bumped by the auto-refresh interval to trigger a re-fetch.
   const [autoRefreshTick, setAutoRefreshTick] = useState(0);
-  const lastTickRef = useRef(autoRefreshTick);
   const serializedFilters = JSON.stringify(filters);
 
   // Fetch data when page, filters, sorting, or refreshKey change
@@ -203,9 +202,10 @@ export function usePartitionedData<T extends object>({
   );
 
   const maxPartitionCount = useMemo(() => {
-    // TODO REST endponts listing partitions are now inconsistent.
-    // We have add getting maxPartitionCount after it is fixed.
-    return data?.totalCount ?? 0;
+    if (!data || data.partitions.length === 0) return 0;
+    // Pagination is driven by the largest partition: pages exist until the
+    // partition with the most items is exhausted.
+    return data.partitions.reduce((max, partition) => Math.max(max, partition.totalCount), 0);
   }, [data]);
 
   return {

--- a/src/components/PartitionedTable/types.ts
+++ b/src/components/PartitionedTable/types.ts
@@ -4,8 +4,8 @@ import type { Column, SortOrder } from '@components/DataTable';
 export interface PartitionData<T> {
   partition: number;
   items: T[];
-  /** Total count of items in this partition (for pagination display) */
-  count?: number;
+  /** Total count of items available in this partition (for pagination display) */
+  totalCount: number;
 }
 
 export interface PartitionedResponse<T> {

--- a/src/mocks/handlers/decisionInstances.ts
+++ b/src/mocks/handlers/decisionInstances.ts
@@ -372,15 +372,14 @@ export const decisionInstanceHandlers = [
       }));
 
       // Return in partitioned format (single partition for mock)
-      // `count` is the total size of the partition (matches the OpenAPI schema
-      // "Total decision instances in this partition" and the process-instance
-      // mock). The bottom pagination is driven by `totalCount`; `count` is
-      // surfaced per-partition via `PartitionHeader`.
+      // Per-partition `totalCount` is the total size of the partition (matches
+      // the OpenAPI schema "Total number of items available in this partition").
+      // The bottom pagination is driven by the max partition `totalCount`.
       return HttpResponse.json({
         partitions: [
           {
             partition: 1,
-            count: filtered.length,
+            totalCount: filtered.length,
             items,
           },
         ],

--- a/src/mocks/handlers/jobs.ts
+++ b/src/mocks/handlers/jobs.ts
@@ -57,6 +57,7 @@ export const jobHandlers = [
         partitions: [
           {
             partition: 1,
+            totalCount: filteredJobs.length,
             items,
           },
         ],

--- a/src/mocks/handlers/processDefinitions.ts
+++ b/src/mocks/handlers/processDefinitions.ts
@@ -235,7 +235,7 @@ export const processDefinitionHandlers = [
       const paginatedItems = allItems.slice(startIndex, endIndex);
 
       return HttpResponse.json({
-        partitions: [{ partition: 1, items: paginatedItems }],
+        partitions: [{ partition: 1, items: paginatedItems, totalCount: allItems.length }],
         page,
         size,
         count: paginatedItems.length,

--- a/src/mocks/handlers/processInstances.ts
+++ b/src/mocks/handlers/processInstances.ts
@@ -265,14 +265,14 @@ export const processInstanceHandlers = [
       });
 
       // Build partitioned response
-      let partitionsResponse: Array<{ partition: number; items: unknown[]; count: number }>;
+      let partitionsResponse: Array<{ partition: number; items: unknown[]; totalCount: number }>;
       let totalCount: number;
 
       if (partition !== null) {
         // Single partition requested - paginate just that partition's data
         const partitionData = partitionMap.get(partition) || [];
         const paginatedItems = partitionData.slice(startIndex, endIndex).map(transformInstance);
-        partitionsResponse = [{ partition, items: paginatedItems, count: partitionData.length }];
+        partitionsResponse = [{ partition, items: paginatedItems, totalCount: partitionData.length }];
         totalCount = partitionData.length;
       } else {
         // All partitions - paginate each partition independently
@@ -280,7 +280,7 @@ export const processInstanceHandlers = [
         partitionsResponse = [1, 2, 3, 4].map((p) => {
           const partitionData = partitionMap.get(p) || [];
           const paginatedItems = partitionData.slice(startIndex, endIndex).map(transformInstance);
-          return { partition: p, items: paginatedItems, count: partitionData.length };
+          return { partition: p, items: paginatedItems, totalCount: partitionData.length };
         });
         // Total count is sum of all items across all partitions
         totalCount = [1, 2, 3, 4].reduce((sum, p) => sum + (partitionMap.get(p)?.length || 0), 0);
@@ -370,7 +370,7 @@ export const processInstanceHandlers = [
       const partitionsResponse = [1, 2, 3, 4].map((p) => {
         const partitionData = partitionMap.get(p) || [];
         const paginatedItems = partitionData.slice(startIndex, endIndex).map(transformInstance);
-        return { partition: p, items: paginatedItems, count: partitionData.length };
+        return { partition: p, items: paginatedItems, totalCount: partitionData.length };
       });
 
       const totalCount = children.length;


### PR DESCRIPTION
 - update API response to use totalCount instead of count for partitioned data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination for partitioned process-instance results by using the largest partition total.
  * Corrected partition totals across decision instances, incidents, jobs, process definitions, and process instances.
  * Ensured filtering and navigation to later pages display complete, accurate results.

* **Documentation**
  * Updated API examples and schemas to consistently describe per-partition `totalCount` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->